### PR TITLE
Fix a typo in using_templates.html.ep

### DIFF
--- a/html/templates/howtos/using_templates.html.ep
+++ b/html/templates/howtos/using_templates.html.ep
@@ -12,7 +12,7 @@
 
 <p>In this example i will show you how to build a ntp module that uploads custom ntp.conf files for your test-, pre-prod-, and production environment.</p>
 
-<p>First, we create a new modul. For this guide you need at least Rex 0.41 (because of the <i>--create-module</i> command and the <i>case</i> keyword.) Execute the following command in the same directory where your <i>Rexfile</i> lives.</p>
+<p>First, we create a new module. For this guide you need at least Rex 0.41 (because of the <i>--create-module</i> command and the <i>case</i> keyword.) Execute the following command in the same directory where your <i>Rexfile</i> lives.</p>
 
 <pre><code class="bash">rexify --create-module=Service::NTP</code></pre>
 


### PR DESCRIPTION
Fix a typo on this page. Change 'modul' to 'module'.
