### PR TITLE
1.0.0.html+md.ep: fix link to Rex::Commands::PkgConf

### DIFF
--- a/html/templates/howtos/releases/1.0.0.html+md.ep
+++ b/html/templates/howtos/releases/1.0.0.html+md.ep
@@ -47,7 +47,7 @@ task "prepare", sub {
 
 #### PkgConf
 
-The PkgConf commands are especially usefull on debian/ubuntu systems to query and to modify package configurations. For example if you want to configure the mysql root password during package installation. To see more example please refer to the <a href="/API/Rex/Commands/PkgConf.pm.html">API</a> documentation.
+The PkgConf commands are especially usefull on debian/ubuntu systems to query and to modify package configurations. For example if you want to configure the mysql root password during package installation. To see more example please refer to the <a href="/api/Rex/Commands/PkgConf.pm.html">API</a> documentation.
 
 * Add PkgConf command to configure packages - Andrew Beverley
 


### PR DESCRIPTION
There's also a corresponding change that needs to be applied in Rex.git, and the POD needs to be regenerated, before the Rex::Commands::PkgConf page will be available on the website; right now it 404's.