### PR TITLE
Complement information about the batch instance

### DIFF
--- a/content/docs/api/1.4/rex/commands.pm.html
+++ b/content/docs/api/1.4/rex/commands.pm.html
@@ -322,6 +322,8 @@
 
 <pre><code> batch &quot;name&quot;, &quot;task1&quot;, &quot;task2&quot;, &quot;task3&quot;;</code></pre>
 
+<p>This must included after the referenced tasks implementation.</p>
+
 <p>And call it with the <i>-b</i> console parameter. <i>rex -b name</i></p>
 
 <h2 id="user-user-">user($user)</h2>


### PR DESCRIPTION
The batch instance must be included after the referenced tasks implementation.
