### PR TITLE
Encode %-sign when Mojo::Template assigns meaning

### DIFF
--- a/content/docs/api/1.3/rex/commands.pm.md
+++ b/content/docs/api/1.3/rex/commands.pm.md
@@ -598,7 +598,7 @@ Set a configuration parameter. These variables can be used in templates as well.
 
 Or in a template
 
-     DB: <%= $::database %>
+     DB: <%%= $::database %>
 
 The following list of configuration parameters are Rex specific:
 
@@ -614,7 +614,7 @@ Get a configuration parameter.
 
 Or in a template
 
-     DB: <%= $::database %>
+     DB: <%%= $::database %>
 
 ## before($task =&gt; sub {})
 
@@ -685,15 +685,15 @@ Note: must come after the definition of the specified task
 
 You can define the logging format with the following parameters.
 
-%D - Appends the current date yyyy-mm-dd HH:mm:ss
+%%D - Appends the current date yyyy-mm-dd HH:mm:ss
 
-%h - The target host
+%%h - The target host
 
-%p - The pid of the running process
+%%p - The pid of the running process
 
-%l - Loglevel (INFO or DEBUG)
+%%l - Loglevel (INFO or DEBUG)
 
-%s - The Logstring
+%%s - The Logstring
 
 Default is: \[%D\] %l - %s
 
@@ -778,13 +778,13 @@ task "mytask", "myserver", sub { my $myvar = { name =&gt; "foo", sys =&gt; "bar"
 
 You can define the format of the say() function.
 
-%D - The current date yyyy-mm-dd HH:mm:ss
+%%D - The current date yyyy-mm-dd HH:mm:ss
 
-%h - The target host
+%%h - The target host
 
-%p - The pid of the running process
+%%p - The pid of the running process
 
-%s - The Logstring
+%%s - The Logstring
 
 You can also define the following values:
 

--- a/content/docs/api/1.3/rex/hardware.pm.md
+++ b/content/docs/api/1.3/rex/hardware.pm.md
@@ -26,13 +26,13 @@ This module is the base class for hardware/information gathering.
 Returns a hash with the wanted information.
 
      task "get-info", "server1", sub {
-       %hw_info = Rex::Hardware->get(qw/ Host Network /);
+       %%hw_info = Rex::Hardware->get(qw/ Host Network /);
      };
 
 Or if you want to get all information
 
      task "get-all-info", "server1", sub {
-       %hw_info = Rex::Hardware->get(qw/ All /);
+       %%hw_info = Rex::Hardware->get(qw/ All /);
      };
 
 Available modules:

--- a/content/docs/api/1.3/rex/logger.pm.md
+++ b/content/docs/api/1.3/rex/logger.pm.md
@@ -36,14 +36,14 @@ If you set this variable to 1 nothing will be logged.
 $format  
 You can define the logging format with the following parameters.
 
-%D - Appends the current date yyyy-mm-dd HH:mm:ss
+%%D - Appends the current date yyyy-mm-dd HH:mm:ss
 
-%h - The target host
+%%h - The target host
 
-%p - The pid of the running process
+%%p - The pid of the running process
 
-%l - Loglevel (INFO or DEBUG)
+%%l - Loglevel (INFO or DEBUG)
 
-%s - The Logstring
+%%s - The Logstring
 
 Default is: \[%D\] %l - %s

--- a/content/docs/api/1.3/rex/template.pm.md
+++ b/content/docs/api/1.3/rex/template.pm.md
@@ -25,4 +25,4 @@ This function will check if $variable is defined. If yes, it will return the val
 
 You can use this function inside your templates.
 
-     ServerTokens <%= is_defined($::server_tokens, "Prod") %>
+     ServerTokens <%%= is_defined($::server_tokens, "Prod") %>

--- a/content/docs/api/1.4/rex/commands.pm.md
+++ b/content/docs/api/1.4/rex/commands.pm.md
@@ -598,7 +598,7 @@ Set a configuration parameter. These variables can be used in templates as well.
 
 Or in a template
 
-     DB: <%= $::database %>
+     DB: <%%= $::database %>
 
 The following list of configuration parameters are Rex specific:
 
@@ -614,7 +614,7 @@ Get a configuration parameter.
 
 Or in a template
 
-     DB: <%= $::database %>
+     DB: <%%= $::database %>
 
 ## before($task =&gt; sub {})
 
@@ -685,15 +685,15 @@ Note: must come after the definition of the specified task
 
 You can define the logging format with the following parameters.
 
-%D - Appends the current date yyyy-mm-dd HH:mm:ss
+%%D - Appends the current date yyyy-mm-dd HH:mm:ss
 
-%h - The target host
+%%h - The target host
 
-%p - The pid of the running process
+%%p - The pid of the running process
 
-%l - Loglevel (INFO or DEBUG)
+%%l - Loglevel (INFO or DEBUG)
 
-%s - The Logstring
+%%s - The Logstring
 
 Default is: \[%D\] %l - %s
 
@@ -778,13 +778,13 @@ task "mytask", "myserver", sub { my $myvar = { name =&gt; "foo", sys =&gt; "bar"
 
 You can define the format of the say() function.
 
-%D - The current date yyyy-mm-dd HH:mm:ss
+%%D - The current date yyyy-mm-dd HH:mm:ss
 
-%h - The target host
+%%h - The target host
 
-%p - The pid of the running process
+%%p - The pid of the running process
 
-%s - The Logstring
+%%s - The Logstring
 
 You can also define the following values:
 

--- a/content/docs/api/1.4/rex/hardware.pm.md
+++ b/content/docs/api/1.4/rex/hardware.pm.md
@@ -26,13 +26,13 @@ This module is the base class for hardware/information gathering.
 Returns a hash with the wanted information.
 
      task "get-info", "server1", sub {
-       %hw_info = Rex::Hardware->get(qw/ Host Network /);
+       %%hw_info = Rex::Hardware->get(qw/ Host Network /);
      };
 
 Or if you want to get all information
 
      task "get-all-info", "server1", sub {
-       %hw_info = Rex::Hardware->get(qw/ All /);
+       %%hw_info = Rex::Hardware->get(qw/ All /);
      };
 
 Available modules:

--- a/content/docs/api/1.4/rex/logger.pm.md
+++ b/content/docs/api/1.4/rex/logger.pm.md
@@ -36,14 +36,14 @@ If you set this variable to 1 nothing will be logged.
 $format  
 You can define the logging format with the following parameters.
 
-%D - Appends the current date yyyy-mm-dd HH:mm:ss
+%%D - Appends the current date yyyy-mm-dd HH:mm:ss
 
-%h - The target host
+%%h - The target host
 
-%p - The pid of the running process
+%%p - The pid of the running process
 
-%l - Loglevel (INFO or DEBUG)
+%%l - Loglevel (INFO or DEBUG)
 
-%s - The Logstring
+%%s - The Logstring
 
 Default is: \[%D\] %l - %s

--- a/content/docs/api/1.4/rex/template.pm.md
+++ b/content/docs/api/1.4/rex/template.pm.md
@@ -25,4 +25,4 @@ This function will check if $variable is defined. If yes, it will return the val
 
 You can use this function inside your templates.
 
-     ServerTokens <%= is_defined($::server_tokens, "Prod") %>
+     ServerTokens <%%= is_defined($::server_tokens, "Prod") %>

--- a/content/docs/guides/using_modules_and_templates.md
+++ b/content/docs/guides/using_modules_and_templates.md
@@ -119,9 +119,9 @@ Now we can create our template. The default template of Rex looks similar to oth
     filegen peerstats file peerstats type day enable
     filegen clockstats file clockstats type day enable
 
-    <% for my $server (@{ $ntp_servers }) { %>
-    server <%= $server %>
-    <% } %>
+    <%% for my $server (@{ $ntp_servers }) { %>
+    server <%%= $server %>
+    <%% } %>
 
 ## Predefined Variables
 
@@ -203,7 +203,7 @@ For example this is the output of a CentOS VM
 
 You can use such predefined variable right in your template. Lets assume you want to bind apache only on your eth1 ip.
 
-    Listen <%= $eth1_ip %>:80
+    Listen <%%= $eth1_ip %>:80
 
 ## Using the Module
 

--- a/content/docs/release_notes/0.24.md
+++ b/content/docs/release_notes/0.24.md
@@ -45,7 +45,7 @@
          __DATA__
          @mytemplate.conf
          <?php
-         $DB['user'] = "<%= $::user %>";
+         $DB['user'] = "<%%= $::user %>";
          @end
 
 -   cloud\_instance command now returns instance info after create

--- a/content/docs/release_notes/0.46.md
+++ b/content/docs/release_notes/0.46.md
@@ -140,7 +140,7 @@ Changes in the Cloud API
 -   Allow passing template content to template command - \#345 - reneeb
 
         file "/etc/file.cnf",
-          content => template(\'<%= $name %> is cool!', name => 'Rex');
+          content => template(\'<%%= $name %> is cool!', name => 'Rex');
 
 -   Added 'no\_cache' feature. If you need to disable the cache, use this.
 

--- a/content/docs/rex_book/the_rex_dsl/using_templates.md
+++ b/content/docs/rex_book/the_rex_dsl/using_templates.md
@@ -4,7 +4,7 @@ The default template engine is a special Rex template engine. The syntax is a bi
 
 For example:
 
-    Hello <%= $name %>!
+    Hello <%%= $name %>!
 
 If $name contains "World" this template would result in the string Hello World!. This is very usefull if you have to maintain a large set of nearly identical configuration files.
 
@@ -26,11 +26,11 @@ First you have to create it
     skip-external-locking
     max_allowed_packet      = 64M
     thread_stack            = 192K
-    max_connections         = <%= exists $conf->{"max_connections"} ? $conf->{"max_connections"} : "1000" %>
+    max_connections         = <%%= exists $conf->{"max_connections"} ? $conf->{"max_connections"} : "1000" %>
 
     max_connect_errors      = 1000
-    table_cache             = <%= exists $conf->{"table_cache"} ? $conf->{"table_cache"} : "5000" %>
-    table_open_cache        = <%= exists $conf->{"table_open_cache"} ? $conf->{"table_open_cache"} : "5000" %>
+    table_cache             = <%%= exists $conf->{"table_cache"} ? $conf->{"table_cache"} : "5000" %>
+    table_open_cache        = <%%= exists $conf->{"table_open_cache"} ? $conf->{"table_open_cache"} : "5000" %>
     thread_concurrency      = 10
 
     #
@@ -80,8 +80,8 @@ When you want to deliver a rexfile that includes the templates, you can use inli
 
     __DATA__
     @test
-    This is a test written by <%= $test->{author} %>
-    for a project called <%= $test->{target} %>
+    This is a test written by <%%= $test->{author} %>
+    for a project called <%%= $test->{target} %>
     @end
 
 The `__DATA__` section is the last section of the Rexfile. The first parameter of the template method call gets the name of the inline template. Note that names of inline templates begin with `@`.
@@ -117,13 +117,13 @@ Rex knows that it has to look up the template in the `__DATA__` section of the f
 
     __DATA__
     @test
-    This is a test written by <%= $test->{author} %>
-    for a project called <%= $test->{target} %>
+    This is a test written by <%%= $test->{author} %>
+    for a project called <%%= $test->{target} %>
     @end
 
     @rex
-    Contribution by <%= $test->{author} %>
-    for a project called <%= $test->{target} %>
+    Contribution by <%%= $test->{author} %>
+    for a project called <%%= $test->{target} %>
     @end
 
 Now we just look at the `__DATA__` section: You notice the token `@end`. This is used to separate the templates. At the end of each template (except for the last one) this token is needed. Otherwise Rex will use everything up to the first `@end` as the template which is most likely too much.

--- a/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
+++ b/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
@@ -101,6 +101,6 @@ To use these information inside the Rexfile you can query them with the get\_sys
 
 You can also use these information inside your template. For example if you want to add the ip address of eth0 or the hostname into a file or change settings of an application based on memory size.
 
-    Listen <%= $eth0_ip %>:80
+    Listen <%%= $eth0_ip %>:80
 
  


### PR DESCRIPTION
A %-sign at the start of a line (preceeded by spaces) or
a '<%' sequence are interpreted as starting Perl code. Encode them
when they are really part of the demo-code provided instead.