### PR TITLE
Migrate book index pages

### DIFF
--- a/content/docs/rex_book/index.md
+++ b/content/docs/rex_book/index.md
@@ -2,4 +2,48 @@
 title: Rex Book (work in progress)
 ---
 
+* [Infrastructure](/docs/rex_book/infrastructure/index.html)  
 
+    * [SSH as an agent](/docs/rex_book/infrastructure/ssh_as_an_agent.html)  
+      To setup an environment to work with Rex you don't have to do much. You have to install Rex on your workstation or a central administration server. For most distributions you'll find packages on the package server.
+
+    * [Version Control with Git](/docs/rex_book/infrastructure/version_control_with_git.html)  
+      We recommend you to use a version control system for your development. Especially if you're working in a team it will bring you many advantages.
+
+    * [Example of a complete Rex code infrastructure](/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.html)  
+      For maintainable and reusable code it is important to start with the right infrastructure choices and tools. In this chapter you will learn how to setup and design your project to achieve this.
+
+* [The Rex DSL](/docs/rex_book/the_rex_dsl/index.html)  
+
+    * [Authentication](/docs/rex_book/the_rex_dsl/authentication.html)  
+      Rex is capable to use two different SSH implementations under the hood: Net::SSH2 which is default on Windows, and the combination of Net::OpenSSH and Net::SFTP::Foreign on other platforms.
+
+    * [Grouping servers](/docs/rex_book/the_rex_dsl/grouping_servers.html)  
+      Rex offers you a powerfull way to group your servers. In this chapter you will learn the basics and also learn how to use databases to generate groups.
+
+    * [Using Environments](/docs/rex_book/the_rex_dsl/using_environments.html)  
+      With environments it is easy to group your servers depending on the maturity of your configuration or your code. You can create environments for dev, staging and production machines. There is no limit for environments, so you can create as much as you need.
+
+    * [Using templates](/docs/rex_book/the_rex_dsl/using_templates.html)  
+      A template is a text file containing special variables or perl code inside it. So with this technique you can generate dynamic configuration files. For example if you want to configure apache only to listen on a special ethernet device (eth0 for example) templates are what you need.
+
+* [Writing Modules](/docs/rex_book/writing_modules/index.html)  
+
+    * [Getting information of the environment](/docs/rex_book/writing_modules/getting_information_of_the_environment.html)  
+      Often you need to know some things of the environment where you are currently connected. For example if you need to install apache on Debian and CentOS you have to provide different packages names.
+
+    * [Writing custom resources](/docs/rex_book/writing_modules/writing_custom_resources.html)  
+      Resoures are the units that are responsible to manage your configurations.
+
+* [Working with Files and Packages](/docs/rex_book/working_with_files_and_packages/index.html)  
+
+    * [Working with Files](/docs/rex_book/working_with_files_and_packages/working_with_files.html)  
+      One task in configuration management is managing files and keeping them in a consistant state. Rex gives you some easy to use functions to work with files.
+
+    * [Installing Packages](/docs/rex_book/working_with_files_and_packages/installing_packages.html)  
+      Installing packages is easy. You can use the pkg function for this.
+
+* [Managing Datacenters and the Cloud](/docs/rex_book/managing_datacenters_and_the_cloud/index.html)  
+
+    * [Deploying OpenLDAP and SSSD](/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.html)  
+      OpenLDAP (http://www.openldap.org/) is an open source directory server widely used for account management. It is easy to setup and administrate. There are also some Webfrontends like http://phpldapadmin.sourceforge.net/ and https://www.ldap-account-manager.org/lamcms/. SSSD (https://fedorahosted.org/sssd/) is the acronym for System Security Services Daemon. With its help it is possible to to authenticate your linux users against an OpenLDAP directory server with some nifty additions like offline support.

--- a/content/docs/rex_book/infrastructure/index.md
+++ b/content/docs/rex_book/infrastructure/index.md
@@ -2,4 +2,11 @@
 title: Infrastructure
 ---
 
+* [SSH as an agent](/docs/rex_book/infrastructure/ssh_as_an_agent.html)  
+  To setup an environment to work with Rex you don't have to do much. You have to install Rex on your workstation or a central administration server. For most distributions you'll find packages on the package server.
 
+* [Version Control with Git](/docs/rex_book/infrastructure/version_control_with_git.html)  
+  We recommend you to use a version control system for your development. Especially if you're working in a team it will bring you many advantages.
+
+* [Example of a complete Rex code infrastructure](/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.html)  
+  For maintainable and reusable code it is important to start with the right infrastructure choices and tools. In this chapter you will learn how to setup and design your project to achieve this.

--- a/content/docs/rex_book/infrastructure/ssh_as_an_agent.md
+++ b/content/docs/rex_book/infrastructure/ssh_as_an_agent.md
@@ -3,6 +3,7 @@ title: SSH as an agent
 ---
 
 To setup an environment to work with Rex you don't have to do much. You have to install Rex on your workstation or a central administration server. For most distributions you'll find packages on the package server. If you want to build Rex from source you have to install the following dependencies.
+
 Perl (at least version 5.8.8)
 
 -   libssh2

--- a/content/docs/rex_book/infrastructure/version_control_with_git.md
+++ b/content/docs/rex_book/infrastructure/version_control_with_git.md
@@ -4,7 +4,7 @@ title: Version Control with Git
 
 We recommend you to use a version control system for your development. Especially if you're working in a team it will bring you many advantages. Also if you want to see the difference between two versions of the same file you can ask your vcs system.
 
-A working vcs is also the base to work in teams. So every teammate can be sure that he/she has the latest available version of the files.
+A working vcs is also the base to work in teams. So every teammate can be sure that he/she has the latest available version of the files.  
 Advantages if you use a VCS
 
 -   You can revert changes
@@ -38,7 +38,3 @@ If you have changed things and want to add them to the repository you have to fo
     $ git add Rexfile
     $ git commit -m "Changed this and that"
     $ git push
-
- 
-
- 

--- a/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
+++ b/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
@@ -66,7 +66,7 @@ With Rex you can use ldap\_entry resource to manage these entries.
 
 The default installation of OpenLDAP is not able to manage SSH Keys inside it. But there is a schema we will add to it later so that this is possible, too.
 
-If you consider to put your OpenLDAP installation to production i recommend you to read<http://www.openldap.org/doc/admin24/replication.html> how to setup replication.
+If you consider to put your OpenLDAP installation to production i recommend you to read <http://www.openldap.org/doc/admin24/replication.html> how to setup replication.
 
 This tutorial also do not cover the access control management. Please read <http://www.openldap.org/doc/admin24/access-control.html> for more information on this topic.
 
@@ -154,7 +154,7 @@ Now lets create a sample group and user.
       sshPublicKey  => 'ssh-rsa AAAAB3NzaC1y...',
       groups => ['cn=ldapusers,ou=Groups,dc=rexify,dc=org'];
 
-This will create a group names ldapusers inside the organizational unit (ou) ou=Groups,dc=rexify,dc=org and a user sampleuser inside ou=People,dc=rexify,dc=org. You can create the crypted password string with the tool slapdpasswd.
+This will create a group names ldapusers inside the organizational unit (ou) ou=Groups,dc=rexify,dc=org and a user sampleuser inside ou=People,dc=rexify,dc=org. You can create the crypted password string with the tool slapdpasswd.  
 Setup SSSD
 
 Now, after you have setup OpenLDAP it is time to setup SSSD. For this there is a task setup\_client inside the Rexfile.
@@ -197,7 +197,3 @@ The configuration of this script can be done in the file /etc/ssh/pubkey.yaml. T
     #tls:
     #        verify: optional
     #        cafile: /etc/openldap/certs/cacert.pem
-
- 
-
- 

--- a/content/docs/rex_book/managing_datacenters_and_the_cloud/index.md
+++ b/content/docs/rex_book/managing_datacenters_and_the_cloud/index.md
@@ -2,4 +2,5 @@
 title: Managing Datacenters and the Cloud
 ---
 
-
+* [Deploying OpenLDAP and SSSD](/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.html)  
+  OpenLDAP (http://www.openldap.org/) is an open source directory server widely used for account management. It is easy to setup and administrate. There are also some Webfrontends like http://phpldapadmin.sourceforge.net/ and https://www.ldap-account-manager.org/lamcms/. SSSD (https://fedorahosted.org/sssd/) is the acronym for System Security Services Daemon. With its help it is possible to to authenticate your linux users against an OpenLDAP directory server with some nifty additions like offline support.

--- a/content/docs/rex_book/the_rex_dsl/authentication.md
+++ b/content/docs/rex_book/the_rex_dsl/authentication.md
@@ -81,7 +81,3 @@ As of version 0.42.0, Rex supports Kerberos authentication through Net::OpenSSH:
 
     user 'root';
     krb5_auth;
-
- 
-
- 

--- a/content/docs/rex_book/the_rex_dsl/grouping_servers.md
+++ b/content/docs/rex_book/the_rex_dsl/grouping_servers.md
@@ -119,7 +119,3 @@ If there is no built-in function that fits your needs for group creation, you ca
     my @list = ("some", "list", "entries");
     group mygroup => grep { /list/ } @list;
     group myserver => map {"s$_.domain.com"} qw(1 3 7);
-
- 
-
- 

--- a/content/docs/rex_book/the_rex_dsl/index.md
+++ b/content/docs/rex_book/the_rex_dsl/index.md
@@ -2,4 +2,14 @@
 title: The Rex DSL
 ---
 
+* [Authentication](/docs/rex_book/the_rex_dsl/authentication.html)  
+  Rex is capable to use two different SSH implementations under the hood: Net::SSH2 which is default on Windows, and the combination of Net::OpenSSH and Net::SFTP::Foreign on other platforms.
 
+* [Grouping servers](/docs/rex_book/the_rex_dsl/grouping_servers.html)  
+  Rex offers you a powerfull way to group your servers. In this chapter you will learn the basics and also learn how to use databases to generate groups.
+
+* [Using Environments](/docs/rex_book/the_rex_dsl/using_environments.html)  
+  With environments it is easy to group your servers depending on the maturity of your configuration or your code. You can create environments for dev, staging and production machines. There is no limit for environments, so you can create as much as you need.
+
+* [Using templates](/docs/rex_book/the_rex_dsl/using_templates.html)  
+  A template is a text file containing special variables or perl code inside it. So with this technique you can generate dynamic configuration files. For example if you want to configure apache only to listen on a special ethernet device (eth0 for example) templates are what you need.

--- a/content/docs/rex_book/working_with_files_and_packages/index.md
+++ b/content/docs/rex_book/working_with_files_and_packages/index.md
@@ -2,4 +2,8 @@
 title: Working with Files and Packages
 ---
 
+* [Working with Files](/docs/rex_book/working_with_files_and_packages/working_with_files.html)  
+  One task in configuration management is managing files and keeping them in a consistant state. Rex gives you some easy to use functions to work with files.
 
+* [Installing Packages](/docs/rex_book/working_with_files_and_packages/installing_packages.html)  
+  Installing packages is easy. You can use the pkg function for this.

--- a/content/docs/rex_book/working_with_files_and_packages/installing_packages.md
+++ b/content/docs/rex_book/working_with_files_and_packages/installing_packages.md
@@ -41,5 +41,3 @@ If you need to write a distribution independent module you can also use the case
        pkg $packages,
          ensure => "present";
     };
-
- 

--- a/content/docs/rex_book/working_with_files_and_packages/working_with_files.md
+++ b/content/docs/rex_book/working_with_files_and_packages/working_with_files.md
@@ -142,5 +142,3 @@ It is also possible to just supervise files if they are present or have special 
         group  => "root",
         mode   => 600;
     };
-
- 

--- a/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
+++ b/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
@@ -106,5 +106,3 @@ To use these information inside the Rexfile you can query them with the get\_sys
 You can also use these information inside your template. For example if you want to add the ip address of eth0 or the hostname into a file or change settings of an application based on memory size.
 
     Listen <%= $eth0_ip %>:80
-
- 

--- a/content/docs/rex_book/writing_modules/index.md
+++ b/content/docs/rex_book/writing_modules/index.md
@@ -2,4 +2,8 @@
 title: Writing Modules
 ---
 
+* [Getting information of the environment](/docs/rex_book/writing_modules/getting_information_of_the_environment.html)  
+  Often you need to know some things of the environment where you are currently connected. For example if you need to install apache on Debian and CentOS you have to provide different packages names.
 
+* [Writing custom resources](/docs/rex_book/writing_modules/writing_custom_resources.html)  
+  Resoures are the units that are responsible to manage your configurations.


### PR DESCRIPTION
There seems to be a big in the MarkDown->HTML generator as the long text on OpenLDAP doesn't get wrapped in P-tags while all others do. I've tried multiple conversions and reductions, but alas, to no effect.

Also, since the "m" (for "managing") comes before the "t" (for "the dsl"), the ordering is off. I wonder how the ordering used to be done for the live site, because I'm unable to find any other key than the name to sort on (to get the order correct).

Based on automated conversion, this the best I can get. I'll be happy to swap the "managing cloud" chapter to the end manually, if that's desirable. I'd rather extend the script if there's an automated indication