### PR TITLE
Add missing index pages (fix #102)

### DIFF
--- a/content/care/index.md
+++ b/content/care/index.md
@@ -1,1 +1,9 @@
+---
+title: Care
+---
 
+* [Help (R)?ex](/care/help__r__ex.html)  
+  Contribute to (R)?ex
+
+* [Help people](/care/help_people_in_need.html)  
+  Help people in need

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -2,4 +2,9 @@
 title: Documentation
 ---
 
-
+* [FAQ](/docs/faq/index.html)  
+* [Guides](docs/guides/index.html)
+* [Rex Book (work in progress)](/docs/rex_book/index.html)
+* [Other](/docs/other/index.html)
+* [Release notes](/docs/release_notes/index.html)
+* [API](https://metacpan.org/release/Rex)


### PR DESCRIPTION
The care and docs index pages were missing their links to their child
entries.

I did not find any good descriptions for most of those links in the old
metadata, so I decided to just list the links in those cases.