### PR TITLE
Cleanup release notes

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -2,3 +2,4 @@
 --indent-columns=2
 --minimum-space-to-comment=1
 --no-outdent-long-quotes
+--no-outdent-long-comments

--- a/content/docs/release_notes/0.10.md
+++ b/content/docs/release_notes/0.10.md
@@ -6,45 +6,47 @@ title: Release notes for 0.10
 
 -   Added a network module
 
-         use Rex::Commands::Network;
-            
-         my @routes = route;
-         print Dumper(\@routes);
-            
-         my $default_gw = default_gateway;
-         default_gateway "192.168.2.1";
-             
-         my @netstat = netstat;
-         my @tcp_connections = grep { $_->{"proto"} eq "tcp" } netstat;
+        use Rex::Commands::Network;
+
+        my @routes = route;
+        print Dumper( \@routes );
+
+        my $default_gw = default_gateway;
+        default_gateway "192.168.2.1";
+
+        my @netstat         = netstat;
+        my @tcp_connections = grep { $_->{"proto"} eq "tcp" } netstat;
 
 -   Added mount and umount functions to the Fs module
 
-         task "mount", "server01", sub {
-            mount "/dev/sda5", "/tmp";
-            mount "/dev/sda6", "/mnt/sda6",
-                       fs => "ext3",
-                       options => [qw/noatime async/];
-         };
+        task "mount", "server01", sub {
+          mount "/dev/sda5", "/tmp";
+          mount "/dev/sda6", "/mnt/sda6",
+            fs      => "ext3",
+            options => [qw/noatime async/];
+        };
 
-         task "umount", "server01", sub {
-            umount "/tmp";
-         };
+        task "umount", "server01", sub {
+          umount "/tmp";
+        };
 
 -   Added a cron module
 
-         use Rex::Commands::Cron;
-             
-         cron add => "root", {
-                    minute => '5',
-                    hour   => '*',
-                    day_of_month    => '*',
-                    month => '*',
-                    day_of_week => '*',
-                 };
-                   
-         cron list => "root";
-              
-         cron delete => "root", 3;
+        use Rex::Commands::Cron;
+
+        cron
+          add => "root",
+          {
+          minute       => '5',
+          hour         => '*',
+          day_of_month => '*',
+          month        => '*',
+          day_of_week  => '*',
+          };
+
+        cron list => "root";
+
+        cron delete => "root", 3;
 
 -   Inventory module
 
@@ -54,13 +56,13 @@ title: Release notes for 0.10
 
     Added a new function *installed\_packages* to get information of all installed packages.
 
-         task "get-installed", "server1", sub {
-            
-             for my $pkg (installed_packages()) {
-                say "name     : " . $pkg->{"name"};
-                say "  version: " . $pkg->{"version"};
-             }
-             
-         };
+        task "get-installed", "server1", sub {
+
+          for my $pkg ( installed_packages() ) {
+            say "name     : " . $pkg->{"name"};
+            say "  version: " . $pkg->{"version"};
+          }
+
+        };
 
 

--- a/content/docs/release_notes/0.10.md
+++ b/content/docs/release_notes/0.10.md
@@ -6,8 +6,6 @@ title: Release notes for 0.10
 
 -   Added a network module
 
-    Copy to clipboard
-
          use Rex::Commands::Network;
             
          my @routes = route;
@@ -21,8 +19,6 @@ title: Release notes for 0.10
 
 -   Added mount and umount functions to the Fs module
 
-    Copy to clipboard
-
          task "mount", "server01", sub {
             mount "/dev/sda5", "/tmp";
             mount "/dev/sda6", "/mnt/sda6",
@@ -35,8 +31,6 @@ title: Release notes for 0.10
          };
 
 -   Added a cron module
-
-    Copy to clipboard
 
          use Rex::Commands::Cron;
              
@@ -59,8 +53,6 @@ title: Release notes for 0.10
 -   Package module
 
     Added a new function *installed\_packages* to get information of all installed packages.
-
-    Copy to clipboard
 
          task "get-installed", "server1", sub {
             

--- a/content/docs/release_notes/0.11.md
+++ b/content/docs/release_notes/0.11.md
@@ -6,8 +6,6 @@ title: Release notes for 0.11
 
 -   Added LVM module and added LVM data to inventory.
 
-    Copy to clipboard
-
          use Rex::Commands::LVM;
            
          task "lvm", sub {
@@ -21,8 +19,6 @@ title: Release notes for 0.11
 -   Added CentOS 6 packages and support
 
 -   added order option to *db select*
-
-    Copy to clipboard
 
          task "db", sub {
             my @data = db select => {

--- a/content/docs/release_notes/0.11.md
+++ b/content/docs/release_notes/0.11.md
@@ -6,13 +6,13 @@ title: Release notes for 0.11
 
 -   Added LVM module and added LVM data to inventory.
 
-         use Rex::Commands::LVM;
-           
-         task "lvm", sub {
-            my @physical_devices = pvs;
-            my @volume_groups = vgs;
-            my @logical_volumes = lvs;
-         };
+        use Rex::Commands::LVM;
+
+        task "lvm", sub {
+          my @physical_devices = pvs;
+          my @volume_groups    = vgs;
+          my @logical_volumes  = lvs;
+        };
 
 -   Added hpacucli support to inventory
 
@@ -20,13 +20,13 @@ title: Release notes for 0.11
 
 -   added order option to *db select*
 
-         task "db", sub {
-            my @data = db select => {
-               fields => "*",
-               from => "table",
-               order => "updated DESC",
-            };
-         };
+        task "db", sub {
+          my @data = db select => {
+            fields => "*",
+            from   => "table",
+            order  => "updated DESC",
+          };
+        };
 
 -   Fixed some bugs
 

--- a/content/docs/release_notes/0.12.md
+++ b/content/docs/release_notes/0.12.md
@@ -6,125 +6,126 @@ title: Release notes for 0.12
 
 -   Added *sudo* command
 
-         sudo_password "mypassword";
-          
-         task "dosomething", sub {
-            say sudo "id";
-         };
+        sudo_password "mypassword";
+
+        task "dosomething", sub {
+          say sudo "id";
+        };
 
 -   Allow to manage multiple services at once.
 
-         task "start", sub {
-            service [qw/apache2 rsyslog ftp/] => "start";
-         };
+        task "start", sub {
+          service [qw/apache2 rsyslog ftp/] => "start";
+        };
 
 -   Added possibility to add and remove services from runlevels
 
-         use Rex::Commands::Iptables;
-         task "prepare", sub {
-            service apache2 => "ensure", "started";
-            service apache2 => "ensure", "stopped";
-         };
+        use Rex::Commands::Iptables;
+        task "prepare", sub {
+          service apache2 => "ensure", "started";
+          service apache2 => "ensure", "stopped";
+        };
 
 -   Added an iptables module to manage basic iptables rules.
 
-         task "firewall", sub {
-            # clear all rules
-            iptables_clear;
-            
-            # open port 22 on all devices
-            open_port 22;
-            
-            # open port 22 and 80 on eth0
-            open_port [22, 80] => {
-               dev => "eth0",
-            };
-            
-            # close all ports on all devices
-            close_port "all";
-            
-            # close port 22 on dev eth0
-            close_port 22 => {
-               dev => "eth0",
-            };
-            
-            # redirect port 80 to 10080
-            redirect_port 80 => 10080;
-            
-            # redirect port 80 to 10080 on eth0
-            redirect_port 80 => {
-               dev => "eth0",
-               to  => 10080,
-            };
-            
-            # set default state rules (RELATED,ESTABLISHED) to accept on all devices
-            default_state_rule;
-             
-            # set default state rules (RELATED,ESTABLISHED) to accept on eth0
-            default_state_rule dev => "eth0";
-            
-            # make the system a nat gateway for its default route
-            # this will set the sysctl entry net.ipv4.ip_forward to 1, too.
-            is_nat_gateway;
-            
-            # define a custom iptables rule
-            iptables t => "filter", A => "INPUT", i => "eth0", ...;
-         };
+        task "firewall", sub {
+
+          # clear all rules
+          iptables_clear;
+
+          # open port 22 on all devices
+          open_port 22;
+
+          # open port 22 and 80 on eth0
+          open_port [ 22, 80 ] => { dev => "eth0", };
+
+          # close all ports on all devices
+          close_port "all";
+
+          # close port 22 on dev eth0
+          close_port 22 => { dev => "eth0", };
+
+          # redirect port 80 to 10080
+          redirect_port 80 => 10080;
+
+          # redirect port 80 to 10080 on eth0
+          redirect_port 80 => {
+            dev => "eth0",
+            to  => 10080,
+          };
+
+        # set default state rules (RELATED,ESTABLISHED) to accept on all devices
+          default_state_rule;
+
+          # set default state rules (RELATED,ESTABLISHED) to accept on eth0
+          default_state_rule dev => "eth0";
+
+          # make the system a nat gateway for its default route
+          # this will set the sysctl entry net.ipv4.ip_forward to 1, too.
+          is_nat_gateway;
+
+          # define a custom iptables rule
+          iptables t => "filter", A => "INPUT", i => "eth0", ...;
+        };
 
 -   Added Amazon EC2 Support
 
-         use Data::Dumper;
-         use Rex::Commands::Cloud;
-           
-         user "root";
-         public_key "/path/to/your/ec2-public.key";
-         private_key "/path/to/your/ec2-private.key.pem";
-            
-         # set the cloud service provider to "Amazon"
-         cloud_service "Amazon";
-           
-         # set cloud auth
-         cloud_auth "$access_key", "$secret_access_key";
-           
-         # set cloud region
-         cloud_region "ec2.eu-west-1.amazonaws.com";
-           
-         # define a group with all running ec2 instances
-         group ec2 => get_cloud_instances_as_group();
-           
-         task "list", sub {
-            print Dumper cloud_instances_list;
-            print Dumper cloud_volume_list;
-             
-            print Dumper get_cloud_regions;
-            print Dumper get_cloud_availability_zones;
-         };
-           
-         task "create", sub {
-            # if you want an ebs volume, create it. if not, you don't need this.
-            my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a"; };
-            
-            # create the cloud instances and attach the just created ebs volume.
-            cloud_instance create => {
-               image_id => "ami-02103876",
-               name     => "test-ec2",
-               key      => "my-test-key",
-               volume   => $vol_id,        # if you don't have a volume, skip this
-               zone     => "eu-west-1a",   # the volume and the instance must be in the same zone. skip this if you don't have a volume.
-            };
-         };
-            
-         task "destroy", sub {
-            cloud_volume detach => "vol-xxaabb";
-            cloud_instance terminate => "i-ffgghhjj";
-            cloud_colume delete => "vol-xxaabb";
-         };
-           
-         task "prepare", group => "ec2", sub {
-            run "apt-get update";
-            install package => "apache2";
-            service apache2 => "start";
-         };
+        use Data::Dumper;
+        use Rex::Commands::Cloud;
+
+        user "root";
+        public_key "/path/to/your/ec2-public.key";
+        private_key "/path/to/your/ec2-private.key.pem";
+
+        # set the cloud service provider to "Amazon"
+        cloud_service "Amazon";
+
+        # set cloud auth
+        cloud_auth "$access_key", "$secret_access_key";
+
+        # set cloud region
+        cloud_region "ec2.eu-west-1.amazonaws.com";
+
+        # define a group with all running ec2 instances
+        group ec2 => get_cloud_instances_as_group();
+
+        task "list", sub {
+          print Dumper cloud_instances_list;
+          print Dumper cloud_volume_list;
+
+          print Dumper get_cloud_regions;
+          print Dumper get_cloud_availability_zones;
+        };
+
+        task "create", sub {
+
+          # if you want an ebs volume, create it. if not, you don't need this.
+          my $vol_id =
+            cloud_volume create => { size => 1, zone => "eu-west-1a"; };
+
+          # create the cloud instances and attach the just created ebs volume.
+          cloud_instance create => {
+            image_id => "ami-02103876",
+            name     => "test-ec2",
+            key      => "my-test-key",
+            volume   => $vol_id,       # if you don't have a volume, skip this
+            zone => "eu-west-1a", # the volume and the instance must be in the same zone. skip this if you don't have a volume.
+          };
+        };
+
+        task "destroy", sub {
+          cloud_volume detach      => "vol-xxaabb";
+          cloud_instance terminate => "i-ffgghhjj";
+          cloud_colume delete      => "vol-xxaabb";
+        };
+
+        task "prepare",
+          group => "ec2",
+          sub {
+          run "apt-get update";
+          install package => "apache2";
+          service apache2 => "start";
+          };
 
 -   Some improvements and bug fixes
 

--- a/content/docs/release_notes/0.12.md
+++ b/content/docs/release_notes/0.12.md
@@ -6,8 +6,6 @@ title: Release notes for 0.12
 
 -   Added *sudo* command
 
-    Copy to clipboard
-
          sudo_password "mypassword";
           
          task "dosomething", sub {
@@ -16,15 +14,11 @@ title: Release notes for 0.12
 
 -   Allow to manage multiple services at once.
 
-    Copy to clipboard
-
          task "start", sub {
             service [qw/apache2 rsyslog ftp/] => "start";
          };
 
 -   Added possibility to add and remove services from runlevels
-
-    Copy to clipboard
 
          use Rex::Commands::Iptables;
          task "prepare", sub {
@@ -33,8 +27,6 @@ title: Release notes for 0.12
          };
 
 -   Added an iptables module to manage basic iptables rules.
-
-    Copy to clipboard
 
          task "firewall", sub {
             # clear all rules
@@ -80,8 +72,6 @@ title: Release notes for 0.12
          };
 
 -   Added Amazon EC2 Support
-
-    Copy to clipboard
 
          use Data::Dumper;
          use Rex::Commands::Cloud;

--- a/content/docs/release_notes/0.13.md
+++ b/content/docs/release_notes/0.13.md
@@ -10,53 +10,56 @@ title: Release notes for 0.13
 
 -   Added support for JiffyBox, a German cloud service of [domainfactory](http://www.df.eu).
 
-         use Rex::Commands::Cloud;
-         
-         user "root";
-         password "f00b4r";
-         pass_auth;
-         
-         cloud_service "Jiffybox";
-         cloud_auth "yourkey";
-         
-         group jiffybox => get_cloud_instances_as_group();
-         
-         task "create", sub {
-            cloud_instance create => {
-               image_id     => "debian_squeeze_64bit",
-               name         => "test01",
-               plan_id      => 10,
-               password     => "f00b4r",
-            };
-         };
-         
-         task "prepare", group => "jiffybox", sub {
-            update_package_db;
-            install package => "apache2";
-         };
+        use Rex::Commands::Cloud;
 
-         $> rex create preare
+        user "root";
+        password "f00b4r";
+        pass_auth;
+
+        cloud_service "Jiffybox";
+        cloud_auth "yourkey";
+
+        group jiffybox => get_cloud_instances_as_group();
+
+        task "create", sub {
+          cloud_instance create => {
+            image_id => "debian_squeeze_64bit",
+            name     => "test01",
+            plan_id  => 10,
+            password => "f00b4r",
+          };
+        };
+
+        task "prepare",
+          group => "jiffybox",
+          sub {
+          update_package_db;
+          install package => "apache2";
+          };
+
+        $> rex create preare
 
 -   Added function to update package database.
 
-         task "update", "server1", "server2", sub {
-            update_package_db;
-         };
+        task "update", "server1", "server2", sub {
+          update_package_db;
+        };
 
 -   Revised error handling. Now every function throws an exception on failure.
 
-         task "test", "server1", "server2", sub {
-            unlink "/tmp/doesntexists";  # this will terminate the whole execution because it will fail.
-            
-            # this will catch the exception and store it in $@
-            eval {
-               unlink "/tmp/doesntexists";
-               # and more stuff
-            } or do {
-               say "Tried to unlink /tmp/doesntexists but it failed.";
-               say "Error: $@";
-            };
-         };
+        task "test", "server1", "server2", sub {
+          unlink "/tmp/doesntexists"; # this will terminate the whole execution because it will fail.
+
+          # this will catch the exception and store it in $@
+          eval {
+            unlink "/tmp/doesntexists";
+
+            # and more stuff
+          } or do {
+            say "Tried to unlink /tmp/doesntexists but it failed.";
+            say "Error: $@";
+          };
+        };
 
 -   added *rm* as an alias function for unlink
 

--- a/content/docs/release_notes/0.13.md
+++ b/content/docs/release_notes/0.13.md
@@ -10,8 +10,6 @@ title: Release notes for 0.13
 
 -   Added support for JiffyBox, a German cloud service of [domainfactory](http://www.df.eu).
 
-    Copy to clipboard
-
          use Rex::Commands::Cloud;
          
          user "root";
@@ -41,15 +39,11 @@ title: Release notes for 0.13
 
 -   Added function to update package database.
 
-    Copy to clipboard
-
          task "update", "server1", "server2", sub {
             update_package_db;
          };
 
 -   Revised error handling. Now every function throws an exception on failure.
-
-    Copy to clipboard
 
          task "test", "server1", "server2", sub {
             unlink "/tmp/doesntexists";  # this will terminate the whole execution because it will fail.

--- a/content/docs/release_notes/0.17.md
+++ b/content/docs/release_notes/0.17.md
@@ -16,58 +16,61 @@ title: Release notes for 0.17
 
     For example with Solaris you can use Blastwave, OpenCSW or the standard utilities for package management.
 
-         # in the base section of your Rexfile
-         package_provider_for SunOS => "Blastwave";
-         
-         task "prepare", "server1", "server2", sub {
-            # if solaris, install apache-22 from Blastwave
-            install package => "apache-22";
-         }; 
+        # in the base section of your Rexfile
+        package_provider_for SunOS => "Blastwave";
+
+        task "prepare", "server1", "server2", sub {
+
+          # if solaris, install apache-22 from Blastwave
+          install package => "apache-22";
+        };
 
     Or, if you want to use OpenCSW
 
-         # in the base section of your Rexfile
-         package_provider_for SunOS => "OpenCSW";
-         
-         task "prepare", "server1", "server2", sub {
-            # if solaris, install apache-22 from OpenCSW
-            install package => "apache-22";
-         }; 
+        # in the base section of your Rexfile
+        package_provider_for SunOS => "OpenCSW";
+
+        task "prepare", "server1", "server2", sub {
+
+          # if solaris, install apache-22 from OpenCSW
+          install package => "apache-22";
+        };
 
     Or, for Solaris 11, use the built-in "pkg" Package Management:
 
-         # in the base section of your Rexfile
-         package_provider_for SunOS => "pkg";
-         
-         task "prepare", "server1", "server2", sub {
-            # if solaris, install apache-22 from built-in pkg
-            install package => "apache-22";
-         }; 
+        # in the base section of your Rexfile
+        package_provider_for SunOS => "pkg";
+
+        task "prepare", "server1", "server2", sub {
+
+          # if solaris, install apache-22 from built-in pkg
+          install package => "apache-22";
+        };
 
 -   Custom providers for service management
 
     For example with Solaris, if you want to use the old init-style service management you don't need to specify anything.
 
-         task "prepare-services", "server1", "server2", sub {
-            service ssh => "restart";
-         };
+        task "prepare-services", "server1", "server2", sub {
+          service ssh => "restart";
+        };
 
     But, if you want to use the newer SVCADM management use this:
 
-         # in the base section of your Rexfile
-         service_provider_for SunOS => "svcadm";
-         
-         task "prepare-services", "server1", "server2", sub {
-            service ssh => "restart";
-         };
+        # in the base section of your Rexfile
+        service_provider_for SunOS => "svcadm";
+
+        task "prepare-services", "server1", "server2", sub {
+          service ssh => "restart";
+        };
 
 -   Added *operating\_system\_version()* to get the OS version.
 
-         task "prepare", "server1", "server2", sub {
-            if(operating_system_version() < 10) {
-               say "too old...";
-            }
-         };
+        task "prepare", "server1", "server2", sub {
+          if ( operating_system_version() < 10 ) {
+            say "too old...";
+          }
+        };
 
 -   fixed local copy error handling
 

--- a/content/docs/release_notes/0.17.md
+++ b/content/docs/release_notes/0.17.md
@@ -16,8 +16,6 @@ title: Release notes for 0.17
 
     For example with Solaris you can use Blastwave, OpenCSW or the standard utilities for package management.
 
-    Copy to clipboard
-
          # in the base section of your Rexfile
          package_provider_for SunOS => "Blastwave";
          
@@ -28,8 +26,6 @@ title: Release notes for 0.17
 
     Or, if you want to use OpenCSW
 
-    Copy to clipboard
-
          # in the base section of your Rexfile
          package_provider_for SunOS => "OpenCSW";
          
@@ -39,8 +35,6 @@ title: Release notes for 0.17
          }; 
 
     Or, for Solaris 11, use the built-in "pkg" Package Management:
-
-    Copy to clipboard
 
          # in the base section of your Rexfile
          package_provider_for SunOS => "pkg";
@@ -54,15 +48,11 @@ title: Release notes for 0.17
 
     For example with Solaris, if you want to use the old init-style service management you don't need to specify anything.
 
-    Copy to clipboard
-
          task "prepare-services", "server1", "server2", sub {
             service ssh => "restart";
          };
 
     But, if you want to use the newer SVCADM management use this:
-
-    Copy to clipboard
 
          # in the base section of your Rexfile
          service_provider_for SunOS => "svcadm";
@@ -72,8 +62,6 @@ title: Release notes for 0.17
          };
 
 -   Added *operating\_system\_version()* to get the OS version.
-
-    Copy to clipboard
 
          task "prepare", "server1", "server2", sub {
             if(operating_system_version() < 10) {

--- a/content/docs/release_notes/0.19.md
+++ b/content/docs/release_notes/0.19.md
@@ -6,7 +6,7 @@ title: Release notes for 0.19
 
 -   Added output modules. First output module is a JUnit compatible output to use Rex together with Jenkins.
 
-         rex -o JUnit $task
+        rex -o JUnit $task
 
     This will product a file junit\_output.xml which can be used by Jenkins.
 
@@ -14,33 +14,35 @@ title: Release notes for 0.19
 
     With environments one can use the same task for different hosts and/or with different credentials. For example if you want to use the same task on your integration, test and production servers.
 
-         # define default user/password
-         user "root";
-         password "foobar";
-         pass_auth;
-             
-         # define default frontend group containing only testwww01
-         group frontend => "testwww01";
-             
-         # define live environment, with different user/password 
-         # and a frontend server group containing www01, www02 and www03
-         environment live => sub {
-            user "root";
-            password "livefoo";
-            pass_auth;
-               
-            group frontend => "www01", "www02", "www03";
-         };
-             
-         # define stage environment with default user and password, but with 
-         # an own frontend group containing only stagewww01
-         environment stage => sub {
-            group frontend => "stagewww01";
-         };
-            
-         task "prepare", group => "frontend", sub {
-             say run "hostname";
-         };
+        # define default user/password
+        user "root";
+        password "foobar";
+        pass_auth;
+
+        # define default frontend group containing only testwww01
+        group frontend => "testwww01";
+
+        # define live environment, with different user/password
+        # and a frontend server group containing www01, www02 and www03
+        environment live => sub {
+          user "root";
+          password "livefoo";
+          pass_auth;
+
+          group frontend => "www01", "www02", "www03";
+        };
+
+        # define stage environment with default user and password, but with
+        # an own frontend group containing only stagewww01
+        environment stage => sub {
+          group frontend => "stagewww01";
+        };
+
+        task "prepare",
+          group => "frontend",
+          sub {
+          say run "hostname";
+          };
 
     -   Calling *rex prepare* will execute on testwww01 with root/foobar credentials
     -   Calling *rex -E live prepare* will execute on www01, www02, www03 with root/livefoo credentials

--- a/content/docs/release_notes/0.19.md
+++ b/content/docs/release_notes/0.19.md
@@ -6,8 +6,6 @@ title: Release notes for 0.19
 
 -   Added output modules. First output module is a JUnit compatible output to use Rex together with Jenkins.
 
-    Copy to clipboard
-
          rex -o JUnit $task
 
     This will product a file junit\_output.xml which can be used by Jenkins.
@@ -15,8 +13,6 @@ title: Release notes for 0.19
 -   Added support for environments.
 
     With environments one can use the same task for different hosts and/or with different credentials. For example if you want to use the same task on your integration, test and production servers.
-
-    Copy to clipboard
 
          # define default user/password
          user "root";

--- a/content/docs/release_notes/0.21.md
+++ b/content/docs/release_notes/0.21.md
@@ -8,8 +8,6 @@ title: Release notes for 0.21
 
     Now you can checkout subversion and git repositories with Rex.
 
-    Copy to clipboard
-
          set repository => "myrepo",
               url => "git@foo.bar:myrepo.git";
             
@@ -21,8 +19,6 @@ title: Release notes for 0.21
 
 -   allow multiple groups for a task
 
-    Copy to clipboard
-
          group "frontend" => "fe01", "fe02";
          group "backend"  => "be01", "be02";
             
@@ -31,8 +27,6 @@ title: Release notes for 0.21
          };
 
 -   every task can have its own auth information
-
-    Copy to clipboard
 
          user "root";
          password "test";
@@ -56,8 +50,6 @@ title: Release notes for 0.21
 
 -   user module: add ssh key
 
-    Copy to clipboard
-
          task "createuser", "server1", sub {
             create_user "foo",
                 home => "/home/foo",
@@ -68,13 +60,9 @@ title: Release notes for 0.21
 
 -   ssh port isn't fix anymore (patch from Jose Luis Martinez)
 
-    Copy to clipboard
-
          group "frontend", "fe01:2222", "fe02";
 
     Rex will now connect to fe01 on port 2222 and to fe02 on port 22.
-
-    Copy to clipboard
 
          port 2222;
          task "prepare", "server1", "server2", sub {
@@ -82,8 +70,6 @@ title: Release notes for 0.21
          };
 
 -   file and upload now scans for environment specific files first
-
-    Copy to clipboard
 
          task "upload", "server1", sub {
             file "/etc/passwd",
@@ -97,8 +83,6 @@ title: Release notes for 0.21
 -   added -nolog parameter to logging function to disable logging at all
 
 -   added possibility to evaluate perl code within the -H CLI parameter
-
-    Copy to clipboard
 
          bash# rex -H 'perl:map { "server-$_"; } (1,2,3)' task
 

--- a/content/docs/release_notes/0.21.md
+++ b/content/docs/release_notes/0.21.md
@@ -8,73 +8,79 @@ title: Release notes for 0.21
 
     Now you can checkout subversion and git repositories with Rex.
 
-         set repository => "myrepo",
-              url => "git@foo.bar:myrepo.git";
-            
-         task "checkout", sub {
-            checkout "myrepo";
-         };
+        set
+          repository => "myrepo",
+          url        => "git@foo.bar:myrepo.git";
+
+        task "checkout", sub {
+          checkout "myrepo";
+        };
 
     See [Rex::Commands::SCM](/api/Rex/Commands/SCM.pm.html) for more information.
 
 -   allow multiple groups for a task
 
-         group "frontend" => "fe01", "fe02";
-         group "backend"  => "be01", "be02";
-            
-         task "prepare", group => [ "frontend", "backend" ], sub {
-            say run "uptime";
-         };
+        group "frontend" => "fe01", "fe02";
+        group "backend"  => "be01", "be02";
+
+        task "prepare",
+          group => [ "frontend", "backend" ],
+          sub {
+          say run "uptime";
+          };
 
 -   every task can have its own auth information
 
-         user "root";
-         password "test";
-            
-         task "prepare", "server1", sub {
-             # will authenticate as root/test
-         };
-           
-         task "prepare2", "server1", sub {
-             # will also authenticate as root/test
-         };
-           
-         # all tasks from here down will authenticate as deploy/testdeploy
-         user "deploy";
-         password "testdeploy";
-         task "deploy", "server1", sub {
-             # will authenticate as deploy/testdeploy
-         };
+        user "root";
+        password "test";
+
+        task "prepare", "server1", sub {
+
+          # will authenticate as root/test
+        };
+
+        task "prepare2", "server1", sub {
+
+          # will also authenticate as root/test
+        };
+
+        # all tasks from here down will authenticate as deploy/testdeploy
+        user "deploy";
+        password "testdeploy";
+        task "deploy", "server1", sub {
+
+          # will authenticate as deploy/testdeploy
+        };
 
 -   fixed running of multiple tasks by do\_task
 
 -   user module: add ssh key
 
-         task "createuser", "server1", sub {
-            create_user "foo",
-                home => "/home/foo",
-                ssh_key => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB...";
-         };
+        task "createuser", "server1", sub {
+          create_user "foo",
+            home    => "/home/foo",
+            ssh_key => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB...";
+        };
 
 -   use generic auth method from Net::SSH2 (patch from Jose Luis Martinez)
 
 -   ssh port isn't fix anymore (patch from Jose Luis Martinez)
 
-         group "frontend", "fe01:2222", "fe02";
+        group "frontend", "fe01:2222", "fe02";
 
     Rex will now connect to fe01 on port 2222 and to fe02 on port 22.
 
-         port 2222;
-         task "prepare", "server1", "server2", sub {
-            # will always connect to port 2222
-         };
+        port 2222;
+        task "prepare", "server1", "server2", sub {
+
+          # will always connect to port 2222
+        };
 
 -   file and upload now scans for environment specific files first
 
-         task "upload", "server1", sub {
-            file "/etc/passwd",
-               source => "files/etc/passwd";
-         };
+        task "upload", "server1", sub {
+          file "/etc/passwd", source => "files/etc/passwd";
+        };
 
     If called with *rex -E stage* it will first try to upload "files/etc/passwd.stage" and if not found "files/etc/passwd"
 
@@ -84,6 +90,6 @@ title: Release notes for 0.21
 
 -   added possibility to evaluate perl code within the -H CLI parameter
 
-         bash# rex -H 'perl:map { "server-$_"; } (1,2,3)' task
+        bash# rex -H 'perl:map { "server-$_"; } (1,2,3)' task
 
 

--- a/content/docs/release_notes/0.22.md
+++ b/content/docs/release_notes/0.22.md
@@ -6,8 +6,6 @@ title: Release notes for 0.22
 
 -   Before and after hooks
 
-    Copy to clipboard
-
            task prepare => "server1", "server2", sub {
               # do something
            };
@@ -29,8 +27,6 @@ title: Release notes for 0.22
 -   Added [FusionInventory](http://fusioninventory.org/) support. If the agent is installed on the target maschine rex will use it for inventory.
 
 -   It's now possible to set crypted passwords.
-
-    Copy to clipboard
 
            task prepare_user => sub {
 

--- a/content/docs/release_notes/0.22.md
+++ b/content/docs/release_notes/0.22.md
@@ -6,21 +6,24 @@ title: Release notes for 0.22
 
 -   Before and after hooks
 
-           task prepare => "server1", "server2", sub {
-              # do something
-           };
-           
-           before prepare => sub {
-              my ($server) = @_;
-              say "Starting virtual machine...";
-              run "xm start $server";
-           };
-           
-           after prepare => sub {
-              my ($server, $failed_connection) = @_;
-              say "Stopping virtual machine...";
-              run "xm stop $server";
-           };
+          task
+            prepare => "server1",
+            "server2", sub {
+
+            # do something
+            };
+
+          before prepare => sub {
+            my ($server) = @_;
+            say "Starting virtual machine...";
+            run "xm start $server";
+          };
+
+          after prepare => sub {
+            my ( $server, $failed_connection ) = @_;
+            say "Stopping virtual machine...";
+            run "xm stop $server";
+          };
 
 -   Systemd service provider for RedHat and SuSE.
 
@@ -28,16 +31,16 @@ title: Release notes for 0.22
 
 -   It's now possible to set crypted passwords.
 
-           task prepare_user => sub {
+          task prepare_user => sub {
 
-              create_user "foo" => {
-                 home => '/home/foo',
-                 groups  => ['users', '...'],
-                 crypt_password => '$1$.yBAfj8a$mQ2SY/lfz8FaSUTgHsP37c/',
-                 ssh_key => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChUw...",
-              };
+            create_user "foo" => {
+              home           => '/home/foo',
+              groups         => [ 'users', '...' ],
+              crypt_password => '$1$.yBAfj8a$mQ2SY/lfz8FaSUTgHsP37c/',
+              ssh_key        => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChUw...",
+            };
 
-           };
+          };
 
 -   Bugs were fixed.
 

--- a/content/docs/release_notes/0.24.md
+++ b/content/docs/release_notes/0.24.md
@@ -6,8 +6,6 @@ title: Release notes for 0.24
 
 -   use Rex as a library for your own project.
 
-    Copy to clipboard
-
          use Rex;
          use Rex::Commands::Run;
          use Rex::Commands::Fs;
@@ -28,16 +26,12 @@ title: Release notes for 0.24
 
 -   Extended Iptables module with a flush command
 
-    Copy to clipboard
-
          use Rex::Commands::Iptables;
          iptables -F;
 
 -   Inline templates
 
     It is now possible to write templates inside your Rexfile.
-
-    Copy to clipboard
 
          task "foo", sub {
              file "/etc/foo",
@@ -56,8 +50,6 @@ title: Release notes for 0.24
 
 -   added CLI parameters to before/around hooks
 
-    Copy to clipboard
-
          task "foo", sub {
             my ($param) = shift;
             # ...
@@ -69,8 +61,6 @@ title: Release notes for 0.24
          };
 
 -   added LVM create functions
-
-    Copy to clipboard
 
          pvcreate "/dev/sda1";
          vgcreate vg0 => "/dev/sda1", "/dev/sda2";

--- a/content/docs/release_notes/0.24.md
+++ b/content/docs/release_notes/0.24.md
@@ -6,40 +6,39 @@ title: Release notes for 0.24
 
 -   use Rex as a library for your own project.
 
-         use Rex;
-         use Rex::Commands::Run;
-         use Rex::Commands::Fs;
-         use Rex::Commands::Pkg;
-         
-         Rex::connect(
-            server => "remotehost",
-            user   => "root",
-            private_key => "/home/jan/.ssh/id_rsa",
-            public_key  => "/home/jan/.ssh/id_rsa.pub",
-         );
-         
-         if(is_file("/etc/sudoers")) {
-             # do something
-         }
-         
-         install package => "apache2";
+        use Rex;
+        use Rex::Commands::Run;
+        use Rex::Commands::Fs;
+        use Rex::Commands::Pkg;
+
+        Rex::connect(
+          server      => "remotehost",
+          user        => "root",
+          private_key => "/home/jan/.ssh/id_rsa",
+          public_key  => "/home/jan/.ssh/id_rsa.pub",
+        );
+
+        if ( is_file("/etc/sudoers") ) {
+
+          # do something
+        }
+
+        install package => "apache2";
 
 -   Extended Iptables module with a flush command
 
-         use Rex::Commands::Iptables;
-         iptables -F;
+        use Rex::Commands::Iptables;
+        iptables -F;
 
 -   Inline templates
 
     It is now possible to write templates inside your Rexfile.
 
-         task "foo", sub {
-             file "/etc/foo",
-                content => template("@mytemplate.conf",
-                    user => 'bar',
-                );
-         };
-         
+        task "foo", sub {
+          file "/etc/foo",
+            content => template( "@mytemplate.conf", user => 'bar', );
+        };
+
          __DATA__
          @mytemplate.conf
          <?php
@@ -50,24 +49,26 @@ title: Release notes for 0.24
 
 -   added CLI parameters to before/around hooks
 
-         task "foo", sub {
-            my ($param) = shift;
-            # ...
-         };
-         
-         before foo => sub {
-            my ($server, $server_ref, $param) = @_;
-            # do something before "foo"
-         };
+        task "foo", sub {
+          my ($param) = shift;
+
+          # ...
+        };
+
+        before foo => sub {
+          my ( $server, $server_ref, $param ) = @_;
+
+          # do something before "foo"
+        };
 
 -   added LVM create functions
 
-         pvcreate "/dev/sda1";
-         vgcreate vg0 => "/dev/sda1", "/dev/sda2";
-         lvcreate "lv0",
-            size => "20G",
-            onvg => "vg0",
-            fstype => "ext3";
+        pvcreate "/dev/sda1";
+        vgcreate vg0 => "/dev/sda1", "/dev/sda2";
+        lvcreate "lv0",
+          size   => "20G",
+          onvg   => "vg0",
+          fstype => "ext3";
 
 -   fixed bugs
 

--- a/content/docs/release_notes/0.25.md
+++ b/content/docs/release_notes/0.25.md
@@ -8,8 +8,8 @@ title: Release notes for 0.25
 
     It is possible to search and use the community recipe directory with the *rexify* command.
 
-         rexify --search term
-         rexify newproject --use Wanted::Module
+        rexify --search term
+        rexify newproject --use Wanted::Module
 
     You can find the [rex-recipes repository here](https://github.com/RexOps/rex-recipes).
 

--- a/content/docs/release_notes/0.25.md
+++ b/content/docs/release_notes/0.25.md
@@ -8,8 +8,6 @@ title: Release notes for 0.25
 
     It is possible to search and use the community recipe directory with the *rexify* command.
 
-    Copy to clipboard
-
          rexify --search term
          rexify newproject --use Wanted::Module
 

--- a/content/docs/release_notes/0.26.md
+++ b/content/docs/release_notes/0.26.md
@@ -8,8 +8,6 @@ title: Release notes for 0.26
 
 -   Added sudo compatibility. Now it is possible to use rex within a sudo environment.
 
-    Copy to clipboard
-
          user "unprivuser";
          sudo_password "f00b4r";
          sudo -on;   # turn sudo globally on
@@ -25,8 +23,6 @@ title: Release notes for 0.26
 
     Or, if you don't want to turn sudo globally on.
 
-    Copy to clipboard
-
          task prepare => sub {
             file "/tmp/foo.txt",
                content => "this file was written without sudo privileges\n";
@@ -41,8 +37,6 @@ title: Release notes for 0.26
 
 -   Added a new function *include* to include Rex recipes without registering the tasks.
 
-    Copy to clipboard
-
          include qw/Webserver::Apache Database::MySQL/;
          
          task prepare => sub {
@@ -51,15 +45,11 @@ title: Release notes for 0.26
 
 -   Added a sed-like function.
 
-    Copy to clipboard
-
          task foo => sub {
             sed qr{search}, "replace", "/path/to/file";
          };
 
 -   Package installation now possible with *install $pkg*.
-
-    Copy to clipboard
 
          task prepare => sub {
             install "foo";
@@ -69,8 +59,6 @@ title: Release notes for 0.26
 
 -   Added *chdir* parameter to *extract* function.
 
-    Copy to clipboard
-
          task prepare => sub {
             extract "/tmp/myfile.tar.gz",
               chdir => "/etc";
@@ -79,8 +67,6 @@ title: Release notes for 0.26
 -   *sync* exclude option now accepts a string or an array of strings. Thanks to Hiroaki Nakamura.
 
 -   Added support for custom init commands.
-
-    Copy to clipboard
 
          task graceful_apache => sub {
             service httpd => "graceful";

--- a/content/docs/release_notes/0.26.md
+++ b/content/docs/release_notes/0.26.md
@@ -8,68 +8,67 @@ title: Release notes for 0.26
 
 -   Added sudo compatibility. Now it is possible to use rex within a sudo environment.
 
-         user "unprivuser";
-         sudo_password "f00b4r";
-         sudo -on;   # turn sudo globally on
-         
-         task prepare => sub {
-            install "apache2";
-            file "/etc/ntp.conf",
-               source => "files/etc/ntp.conf",
-               owner  => "root",
-               mode   => 640;
-         };
-         
+        user "unprivuser";
+        sudo_password "f00b4r";
+        sudo -on; # turn sudo globally on
+
+        task prepare => sub {
+          install "apache2";
+          file "/etc/ntp.conf",
+            source => "files/etc/ntp.conf",
+            owner  => "root",
+            mode   => 640;
+        };
 
     Or, if you don't want to turn sudo globally on.
 
-         task prepare => sub {
-            file "/tmp/foo.txt",
-               content => "this file was written without sudo privileges\n";
-            
-            # everything in this section will be executed with sudo privileges
-            sudo sub {
-               install "apache2";
-               file "/tmp/foo2.txt",
-                  content => "this file was written with sudo privileges\n";
-            };
-         };
+        task prepare => sub {
+          file "/tmp/foo.txt",
+            content => "this file was written without sudo privileges\n";
+
+          # everything in this section will be executed with sudo privileges
+          sudo sub {
+            install "apache2";
+            file "/tmp/foo2.txt",
+              content => "this file was written with sudo privileges\n";
+          };
+        };
 
 -   Added a new function *include* to include Rex recipes without registering the tasks.
 
-         include qw/Webserver::Apache Database::MySQL/;
-         
-         task prepare => sub {
-            Webserver::Apache::setup();
-         };
+        include qw/Webserver::Apache Database::MySQL/;
+
+        task prepare => sub {
+          Webserver::Apache::setup();
+        };
 
 -   Added a sed-like function.
 
-         task foo => sub {
-            sed qr{search}, "replace", "/path/to/file";
-         };
+        task foo => sub {
+          sed qr{search}, "replace", "/path/to/file";
+        };
 
 -   Package installation now possible with *install $pkg*.
 
-         task prepare => sub {
-            install "foo";
-            # old way
-            install package => "foo";
-         };
+        task prepare => sub {
+          install "foo";
+
+          # old way
+          install package => "foo";
+        };
 
 -   Added *chdir* parameter to *extract* function.
 
-         task prepare => sub {
-            extract "/tmp/myfile.tar.gz",
-              chdir => "/etc";
-         };
+        task prepare => sub {
+          extract "/tmp/myfile.tar.gz", chdir => "/etc";
+        };
 
 -   *sync* exclude option now accepts a string or an array of strings. Thanks to Hiroaki Nakamura.
 
 -   Added support for custom init commands.
 
-         task graceful_apache => sub {
-            service httpd => "graceful";
-         };
+        task graceful_apache => sub {
+          service httpd => "graceful";
+        };
 
 

--- a/content/docs/release_notes/0.27.md
+++ b/content/docs/release_notes/0.27.md
@@ -8,16 +8,16 @@ title: Release notes for 0.27
 
 -   Added callback function to run command
 
-         task "foo", sub {
-            run "ls -l ", sub {
-               my ($stdout, $stderr) = @_;
-               print ">> $stdout\n";
-            };
-         };
+        task "foo", sub {
+          run "ls -l ", sub {
+            my ( $stdout, $stderr ) = @_;
+            print ">> $stdout\n";
+          };
+        };
 
 -   Added possibility to change logging format
 
-         logformat "[%D] - %h %p";
+        logformat "[%D] - %h %p";
 
     See [Rex::Commands](/api/Rex/Commands.pm.html) for more information.
 
@@ -25,12 +25,11 @@ title: Release notes for 0.27
 
 -   Added on\_change option to sed command. Thanks to Samuele Tognini.
 
-         task "foo", sub {
-            sed qr{search}, "replace", "/var/log/auth.log",
-                   on_change => sub {
-                      say "file was changed";
-                   };
-         }; 
+        task "foo", sub {
+          sed qr{search}, "replace", "/var/log/auth.log", on_change => sub {
+            say "file was changed";
+          };
+        };
 
 -   Fixed a bug with an older LVM version
 

--- a/content/docs/release_notes/0.27.md
+++ b/content/docs/release_notes/0.27.md
@@ -8,8 +8,6 @@ title: Release notes for 0.27
 
 -   Added callback function to run command
 
-    Copy to clipboard
-
          task "foo", sub {
             run "ls -l ", sub {
                my ($stdout, $stderr) = @_;
@@ -19,8 +17,6 @@ title: Release notes for 0.27
 
 -   Added possibility to change logging format
 
-    Copy to clipboard
-
          logformat "[%D] - %h %p";
 
     See [Rex::Commands](/api/Rex/Commands.pm.html) for more information.
@@ -28,8 +24,6 @@ title: Release notes for 0.27
 -   Added colorized output if Term::ANSIColor is available.
 
 -   Added on\_change option to sed command. Thanks to Samuele Tognini.
-
-    Copy to clipboard
 
          task "foo", sub {
             sed qr{search}, "replace", "/var/log/auth.log",

--- a/content/docs/release_notes/0.28.md
+++ b/content/docs/release_notes/0.28.md
@@ -6,8 +6,6 @@ title: Release notes for 0.28
 
 -   Added a new CLI parameter "-Tv" to display more information of tasks.
 
-    Copy to clipboard
-
          jan@pitahaya ~/temp $ rex -Tv
          Tasks
            foo                            
@@ -21,8 +19,6 @@ title: Release notes for 0.28
 -   Fixed a bug with relative source file names inside external modules
 
 -   allow additional parameters for rsync
-
-    Copy to clipboard
 
          task "syncr", "server1", sub {
             sync "/packages/www", "/var/www/html", {

--- a/content/docs/release_notes/0.28.md
+++ b/content/docs/release_notes/0.28.md
@@ -6,25 +6,24 @@ title: Release notes for 0.28
 
 -   Added a new CLI parameter "-Tv" to display more information of tasks.
 
-         jan@pitahaya ~/temp $ rex -Tv
-         Tasks
-           foo                            
-               Servers: 
-           test                           
-               Servers: server01, server02, server03
-           test2                          
-               Servers: wks01, wks02
-         
+        jan@pitahaya ~/temp $ rex -Tv
+        Tasks
+          foo                            
+              Servers: 
+          test                           
+              Servers: server01, server02, server03
+          test2                          
+              Servers: wks01, wks02
+
 
 -   Fixed a bug with relative source file names inside external modules
 
 -   allow additional parameters for rsync
 
-         task "syncr", "server1", sub {
-            sync "/packages/www", "/var/www/html", {
-                parameters => "--backup --delete ...",   
-            };
-         };
+        task "syncr", "server1", sub {
+          sync "/packages/www", "/var/www/html",
+            { parameters => "--backup --delete ...", };
+        };
 
 -   fixed a bug in the libvirt module if only one guest-type is available.
 

--- a/content/docs/release_notes/0.29.md
+++ b/content/docs/release_notes/0.29.md
@@ -30,8 +30,6 @@ title: Release notes for 0.29
 
 -   Added experimental feature: shared variables
 
-    Copy to clipboard
-
          BEGIN {
             use Rex::Shared::Var;
             share(qw($scalar @array %hash));

--- a/content/docs/release_notes/0.29.md
+++ b/content/docs/release_notes/0.29.md
@@ -30,11 +30,10 @@ title: Release notes for 0.29
 
 -   Added experimental feature: shared variables
 
-         BEGIN {
-            use Rex::Shared::Var;
-            share(qw($scalar @array %hash));
-         }
-         
+        BEGIN {
+          use Rex::Shared::Var;
+          share(qw($scalar @array %hash));
+        }
 
     These variables get shared across the tasks.
 

--- a/content/docs/release_notes/0.3.md
+++ b/content/docs/release_notes/0.3.md
@@ -8,8 +8,6 @@ title: Release notes for 0.3
 
     A simple rsync interface is now available. To use it, you need the Perl module <span>Expect</span>.
 
-    Copy to clipboard
-
          use Rex::Commands::Rsync;
          
          desc "Sync /etc";
@@ -18,8 +16,6 @@ title: Release notes for 0.3
          };
 
     Or, if you want to sync a remote directory to a local one
-
-    Copy to clipboard
 
          task "get-logs", "server", sub {
              sync "/var/log", "/tmp/logs", { download => 1 };
@@ -35,13 +31,9 @@ title: Release notes for 0.3
 
     Log to a file:
 
-    Copy to clipboard
-
          logging to_file => 'rex.log';
 
     Log to syslog:
-
-    Copy to clipboard
 
          logging to_syslog => 'local0';
 
@@ -49,15 +41,11 @@ title: Release notes for 0.3
 
     Now you can define server ranges like "www\[1..10\]" or "www\[01..10\]".
 
-    Copy to clipboard
-
          task "uname", "www[1..10]", sub {
             run "uname -a";
          };
 
     or
-
-    Copy to clipboard
 
          group "webserver" => "www[01..15]", "web[1..3]";
          task "uname", group => "webserver", sub {
@@ -68,19 +56,13 @@ title: Release notes for 0.3
 
     Example:
 
-    Copy to clipboard
-
          rex -e "run 'hostname'" -H "www01 www02 www03" -u root -p password
 
     or with server ranges
 
-    Copy to clipboard
-
          rex -e "run 'hostname'" -H "www[01..10]" -u root -p password
 
     or if you only want to get the hostname from every 3rd server
-
-    Copy to clipboard
 
          rex -e "run 'hostname'" -H "www[01..10/3]" -u root -p password
 
@@ -89,8 +71,6 @@ title: Release notes for 0.3
     Now you can call tasks from other tasks.
 
     Example:
-
-    Copy to clipboard
 
          task "hostname", "server1", "server2", sub {
             run "hostname";
@@ -104,8 +84,6 @@ title: Release notes for 0.3
 ## rexify
 
 -   A simple command to create a Rexfile skeleton.
-
-    Copy to clipboard
 
          rexify ProjectName
 

--- a/content/docs/release_notes/0.3.md
+++ b/content/docs/release_notes/0.3.md
@@ -8,18 +8,18 @@ title: Release notes for 0.3
 
     A simple rsync interface is now available. To use it, you need the Perl module <span>Expect</span>.
 
-         use Rex::Commands::Rsync;
-         
-         desc "Sync /etc";
-         task "etc", "server1", "server2", "server3", sub {
-            sync "/filestore/public/etc", "/etc";
-         };
+        use Rex::Commands::Rsync;
+
+        desc "Sync /etc";
+        task "etc", "server1", "server2", "server3", sub {
+          sync "/filestore/public/etc", "/etc";
+        };
 
     Or, if you want to sync a remote directory to a local one
 
-         task "get-logs", "server", sub {
-             sync "/var/log", "/tmp/logs", { download => 1 };
-         };
+        task "get-logs", "server", sub {
+          sync "/var/log", "/tmp/logs", { download => 1 };
+        };
 
 -   **Debug mode**
 
@@ -31,40 +31,42 @@ title: Release notes for 0.3
 
     Log to a file:
 
-         logging to_file => 'rex.log';
+        logging to_file => 'rex.log';
 
     Log to syslog:
 
-         logging to_syslog => 'local0';
+        logging to_syslog => 'local0';
 
 -   **Server ranges**
 
     Now you can define server ranges like "www\[1..10\]" or "www\[01..10\]".
 
-         task "uname", "www[1..10]", sub {
-            run "uname -a";
-         };
+        task "uname", "www[1..10]", sub {
+          run "uname -a";
+        };
 
     or
 
-         group "webserver" => "www[01..15]", "web[1..3]";
-         task "uname", group => "webserver", sub {
-            run "uname -a";
-         };
+        group "webserver" => "www[01..15]", "web[1..3]";
+        task "uname",
+          group => "webserver",
+          sub {
+          run "uname -a";
+          };
 
 -   **Run command from commandline**
 
     Example:
 
-         rex -e "run 'hostname'" -H "www01 www02 www03" -u root -p password
+        rex -e "run 'hostname'" -H "www01 www02 www03" -u root -p password
 
     or with server ranges
 
-         rex -e "run 'hostname'" -H "www[01..10]" -u root -p password
+        rex -e "run 'hostname'" -H "www[01..10]" -u root -p password
 
     or if you only want to get the hostname from every 3rd server
 
-         rex -e "run 'hostname'" -H "www[01..10/3]" -u root -p password
+        rex -e "run 'hostname'" -H "www[01..10/3]" -u root -p password
 
 -   **Call tasks from other tasks**
 
@@ -72,20 +74,20 @@ title: Release notes for 0.3
 
     Example:
 
-         task "hostname", "server1", "server2", sub {
-            run "hostname";
-            do_task "uname";
-         };
+        task "hostname", "server1", "server2", sub {
+          run "hostname";
+          do_task "uname";
+        };
 
-         task "uname", "server1", "server2", sub {
-            run "uname -a";
-         };
+        task "uname", "server1", "server2", sub {
+          run "uname -a";
+        };
 
 ## rexify
 
 -   A simple command to create a Rexfile skeleton.
 
-         rexify ProjectName
+        rexify ProjectName
 
     This will create a *Rexfile* and file *lib/Rex/ProjectName.pm* where you can define your tasks.
 

--- a/content/docs/release_notes/0.30.md
+++ b/content/docs/release_notes/0.30.md
@@ -6,8 +6,6 @@ title: Release notes for 0.30
 
 -   2 functions to get more details of users.
 
-    Copy to clipboard
-
          # to get a list of all users
          my @users = user_list();
          # to get the groups of user "foo"
@@ -23,16 +21,12 @@ title: Release notes for 0.30
 
 -   Added support for task specific parallelism
 
-    Copy to clipboard
-
          task "foo", group => "myservers", sub {
             # print do something
          };
          Rex::TaskList->get_task("foo")->set_parallelism(10);
 
 -   Added on\_change support to the append\_if\_no\_such\_line function.
-
-    Copy to clipboard
 
          task "foo", group => "myservers", sub {
              append_if_no_such_line "/etc/groups", "mygroup:*:100:myuser1,myuser2",

--- a/content/docs/release_notes/0.30.md
+++ b/content/docs/release_notes/0.30.md
@@ -6,10 +6,11 @@ title: Release notes for 0.30
 
 -   2 functions to get more details of users.
 
-         # to get a list of all users
-         my @users = user_list();
-         # to get the groups of user "foo"
-         my @groups = user_groups("foo");
+        # to get a list of all users
+        my @users = user_list();
+
+        # to get the groups of user "foo"
+        my @groups = user_groups("foo");
 
 -   New option "type" for the extract function to force the archive type.
 
@@ -21,17 +22,21 @@ title: Release notes for 0.30
 
 -   Added support for task specific parallelism
 
-         task "foo", group => "myservers", sub {
-            # print do something
-         };
-         Rex::TaskList->get_task("foo")->set_parallelism(10);
+        task "foo",
+          group => "myservers",
+          sub {
+          # print do something
+          };
+        Rex::TaskList->get_task("foo")->set_parallelism(10);
 
 -   Added on\_change support to the append\_if\_no\_such\_line function.
 
-         task "foo", group => "myservers", sub {
-             append_if_no_such_line "/etc/groups", "mygroup:*:100:myuser1,myuser2",
-                   on_change => sub { print "/etc/groups was changed...\n"; };
-         };
+        task "foo",
+          group => "myservers",
+          sub {
+          append_if_no_such_line "/etc/groups", "mygroup:*:100:myuser1,myuser2",
+            on_change => sub { print "/etc/groups was changed...\n"; };
+          };
 
 ## Bugfixes
 

--- a/content/docs/release_notes/0.31.md
+++ b/content/docs/release_notes/0.31.md
@@ -16,8 +16,6 @@ title: Release notes for 0.31
 
     You can active new features by version in your Rexfile.
 
-    Copy to clipboard
-
          # Rexfile
          use Rex -feature => 0.31;
            
@@ -32,8 +30,6 @@ title: Release notes for 0.31
     You have to define the groups and tasks first before you can modify the authentication for them.
 
     Authentication settings for tasks have always precedence over group settings.
-
-    Copy to clipboard
 
          use Rex -feature => 0.31;
           

--- a/content/docs/release_notes/0.31.md
+++ b/content/docs/release_notes/0.31.md
@@ -16,14 +16,14 @@ title: Release notes for 0.31
 
     You can active new features by version in your Rexfile.
 
-         # Rexfile
-         use Rex -feature => 0.31;
-           
-         user "root";
-         password "foo";
-          
-         task prepare => sub {
-         };
+        # Rexfile
+        use Rex -feature => 0.31;
+
+        user "root";
+        password "foo";
+
+        task prepare => sub {
+        };
 
 -   Set authentication per group or task (only with 0.31 features enabled)
 
@@ -31,26 +31,25 @@ title: Release notes for 0.31
 
     Authentication settings for tasks have always precedence over group settings.
 
-         use Rex -feature => 0.31;
-          
-         group frontends => "web[01..10]";
-         group backends => "be[01..05]";
-           
-         auth for => "frontends" => 
-                          user => "root",
-                          password => "foobar";
-            
-         auth for => "backends" =>
-                          user => "admin",
-                          private_key => "/path/to/id_rsa",
-                          public_key => "/path/to/id_rsa.pub",
-                          sudo => TRUE;
-            
-         task "prepare", group => ["frontends", "backends"], sub {
-            # do something
-         };
-            
-         auth for => "prepare" =>
-                          user => "root";
+        use Rex -feature => 0.31;
+
+        group frontends => "web[01..10]";
+        group backends  => "be[01..05]";
+
+        auth for   => "frontends" => user => "root",
+          password => "foobar";
+
+        auth for      => "backends" => user => "admin",
+          private_key => "/path/to/id_rsa",
+          public_key  => "/path/to/id_rsa.pub",
+          sudo        => TRUE;
+
+        task "prepare",
+          group => [ "frontends", "backends" ],
+          sub {
+          # do something
+          };
+
+        auth for => "prepare" => user => "root";
 
 

--- a/content/docs/release_notes/0.33.md
+++ b/content/docs/release_notes/0.33.md
@@ -14,15 +14,11 @@ title: Release notes for 0.33
 
     If you want to generate a profiling output you can do this with:
 
-    Copy to clipboard
-
          rex -dd $yourtask
 
 -   Mounting (thanks to Laird Liu)
 
     It is now possible to write mount entries to /etc/fstab with the *persistent* option.
-
-    Copy to clipboard
 
          mount "/dev/sda5", "/mnt/sda5",
             persistent => TRUE;
@@ -30,8 +26,6 @@ title: Release notes for 0.33
 -   Partitioning
 
     It is now possible to mount the new created partition.
-
-    Copy to clipboard
 
          partition "/",
             fstype => "ext3",
@@ -41,8 +35,6 @@ title: Release notes for 0.33
             mount  => TRUE;
 
     And if you want to write fstab entries directly.
-
-    Copy to clipboard
 
          partition "/",
             fstype => "ext3",
@@ -54,8 +46,6 @@ title: Release notes for 0.33
 -   New keyword *make*.
 
     This is just a cosmetic one. It is now possible to write tasks this way:
-
-    Copy to clipboard
 
          # old
          task prepare => sub {
@@ -88,8 +78,6 @@ title: Release notes for 0.33
 
     If the *ssh\_key* option is set it will only create the .ssh directory if the home directory exists.
 
-    Copy to clipboard
-
          create_user "foo",
              home => "/data/homes/foo",
              no_create_home => TRUE;
@@ -101,8 +89,6 @@ title: Release notes for 0.33
 -   Template class now exchangeable (thanks to Laird Liu)
 
     If you want to use another Template class (for example Template::Toolkit) you can use it now.
-
-    Copy to clipboard
 
          # Rexfile
          use strict;

--- a/content/docs/release_notes/0.33.md
+++ b/content/docs/release_notes/0.33.md
@@ -14,59 +14,63 @@ title: Release notes for 0.33
 
     If you want to generate a profiling output you can do this with:
 
-         rex -dd $yourtask
+        rex -dd $yourtask
 
 -   Mounting (thanks to Laird Liu)
 
     It is now possible to write mount entries to /etc/fstab with the *persistent* option.
 
-         mount "/dev/sda5", "/mnt/sda5",
-            persistent => TRUE;
+        mount "/dev/sda5", "/mnt/sda5", persistent => TRUE;
 
 -   Partitioning
 
     It is now possible to mount the new created partition.
 
-         partition "/",
-            fstype => "ext3",
-            size   => 15000,
-            ondisk => "sda",
-            type   => "primary",
-            mount  => TRUE;
+        partition "/",
+          fstype => "ext3",
+          size   => 15000,
+          ondisk => "sda",
+          type   => "primary",
+          mount  => TRUE;
 
     And if you want to write fstab entries directly.
 
-         partition "/",
-            fstype => "ext3",
-            size   => 15000,
-            ondisk => "sda",
-            type   => "primary",
-            mount_persistent  => TRUE;
+        partition "/",
+          fstype           => "ext3",
+          size             => 15000,
+          ondisk           => "sda",
+          type             => "primary",
+          mount_persistent => TRUE;
 
 -   New keyword *make*.
 
     This is just a cosmetic one. It is now possible to write tasks this way:
 
-         # old
-         task prepare => sub {
-            # do something
-         };
-         
-         # new
-         task prepare => make {
-             # do something
-         };
+        # old
+        task prepare => sub {
 
+          # do something
+        };
 
-         # old
-         task "prepare", group => "foo", sub {
-             # do something
-         };
-         
-         # new
-         task "prepare", group => "foo", make {
-            # do something
-         };
+        # new
+        task prepare => make {
+
+          # do something
+        };
+
+        # old
+        task "prepare",
+          group => "foo",
+          sub {
+          # do something
+          };
+
+        # new
+        task "prepare",
+          group => "foo",
+          make {
+          # do something
+          };
 
 -   Usability improvements, thanks to Anders Ossowicki
 
@@ -78,9 +82,9 @@ title: Release notes for 0.33
 
     If the *ssh\_key* option is set it will only create the .ssh directory if the home directory exists.
 
-         create_user "foo",
-             home => "/data/homes/foo",
-             no_create_home => TRUE;
+        create_user "foo",
+          home           => "/data/homes/foo",
+          no_create_home => TRUE;
 
 -   Fixed *expire* bug for create\_user
 
@@ -90,27 +94,28 @@ title: Release notes for 0.33
 
     If you want to use another Template class (for example Template::Toolkit) you can use it now.
 
-         # Rexfile
-         use strict;
-         use warnings;
-          
-         use Template;
-          
-         set template_function => sub {
-            my ($content, $vars) = @_;
-            my $t = Template->new;
-            my $out;
-            $t->process(\$content, $vars, \$out);
-            return $out;
-         };
-          
-         task foo => sub {
-            file "/etc/foo/service.conf",
-               content => template("service.conf.tpl", 
-                                       name => "foo",
-                                       port => 1903
-                          );
-         };
+        # Rexfile
+        use strict;
+        use warnings;
+
+        use Template;
+
+        set template_function => sub {
+          my ( $content, $vars ) = @_;
+          my $t = Template->new;
+          my $out;
+          $t->process( \$content, $vars, \$out );
+          return $out;
+        };
+
+        task foo => sub {
+          file "/etc/foo/service.conf",
+            content => template(
+            "service.conf.tpl",
+            name => "foo",
+            port => 1903
+            );
+        };
 
 # Modules
 

--- a/content/docs/release_notes/0.35.md
+++ b/content/docs/release_notes/0.35.md
@@ -16,8 +16,6 @@ A website where you can download prebuilt Boxes and find information about Rex/B
 
 -   VirtualBox support for Rex::Commands::Virtualization
 
-Copy to clipboard
-
     use Rex::Commands::Virtualization;
 
     set virtualization => "VBox";
@@ -57,8 +55,6 @@ Copy to clipboard
 -   Rex::Commands::Box
 
 Functions to easily work with VirtualBox images.
-
-Copy to clipboard
 
      use Rex::Commands::Box;
 
@@ -105,8 +101,6 @@ Copy to clipboard
 
 -   **auth for** now works with regular expresions.
 
-Copy to clipboard
-
      # Rexfile
 
      task foo => sub {
@@ -121,8 +115,6 @@ Copy to clipboard
          password => "foob4r";
 
 -   It is now possible to use the **repository** function for multiple distributions.
-
-Copy to clipboard
 
      task "add-repo", "server1", "server2", sub {
        repository add => myrepo => {
@@ -145,8 +137,6 @@ Copy to clipboard
 The key that is used is the return value of **get\_operating\_system()**.
 
 It is also possible to add an **after** hook like this:
-
-Copy to clipboard
 
      task "add-repo", "server1", "server2", sub {
        repository add => myrepo => {

--- a/content/docs/release_notes/0.35.md
+++ b/content/docs/release_notes/0.35.md
@@ -16,154 +16,160 @@ A website where you can download prebuilt Boxes and find information about Rex/B
 
 -   VirtualBox support for Rex::Commands::Virtualization
 
-    use Rex::Commands::Virtualization;
+        use Rex::Commands::Virtualization;
 
-    set virtualization => "VBox";
+        set virtualization => "VBox";
 
-    use Data::Dumper;   
+        use Data::Dumper;
 
-    print Dumper vm list => "all";
-    print Dumper vm list => "running";
+        print Dumper vm list => "all";
+        print Dumper vm list => "running";
 
-    vm destroy => "vm01";
+        vm destroy => "vm01";
 
-    vm delete => "vm01"; 
+        vm delete => "vm01";
 
-    vm start => "vm01";
+        vm start => "vm01";
 
-    vm shutdown => "vm01";
+        vm shutdown => "vm01";
 
-    vm reboot => "vm01";
+        vm reboot => "vm01";
 
-    vm option => "vm01",
-             memory     => 512;
+        vm
+          option => "vm01",
+          memory => 512;
 
-    print Dumper vm info => "vm01";
+        print Dumper vm info => "vm01";
 
-    # creating a vm 
-    vm create => "vm01",
-          storage     => [
-             {   
-                file   => "/mnt/data/vbox/vm01.img",
-             }
+        # creating a vm
+        vm
+          create  => "vm01",
+          storage => [
+          {
+            file => "/mnt/data/vbox/vm01.img",
+          }
           ],
           memory => 512,
-          type => "Linux26", 
-          cpus => 1,
-          boot => "cdrom";
+          type   => "Linux26",
+          cpus   => 1,
+          boot   => "cdrom";
 
 -   Rex::Commands::Box
 
 Functions to easily work with VirtualBox images.
 
-     use Rex::Commands::Box;
+    use Rex::Commands::Box;
 
-     task "init", sub {
+    task "init", sub {
 
-       my $param = shift;
+      my $param = shift;
 
-       box {
-          my ($box) = @_;
-          $box->name($param->{name});
-          $box->url($param->{url});
-          $box->network(1 => {
-             type => "nat",
-          });
+      box {
+        my ($box) = @_;
+        $box->name( $param->{name} );
+        $box->url( $param->{url} );
+        $box->network(
+          1 => {
+            type => "nat",
+          }
+        );
 
-          # only works with network type = nat
-          # if an ssh key is present, rex will use this to log into the vm
-          # you need this if you don't run VirtualBox on your local host.
-          $box->forward_port(ssh => [2222 => 22]);
+        # only works with network type = nat
+        # if an ssh key is present, rex will use this to log into the vm
+        # you need this if you don't run VirtualBox on your local host.
+        $box->forward_port( ssh => [ 2222 => 22 ] );
 
-          $box->share_folder("myhome" => "/home/jan");
+        $box->share_folder( "myhome" => "/home/jan" );
 
-          $box->auth(
-             user => "root",
-             password => "box",
-          );
+        $box->auth(
+          user     => "root",
+          password => "box",
+        );
 
-          $box->setup(qw/install_webserver/);
-       };
+        $box->setup(qw/install_webserver/);
+      };
 
-     };
+    };
 
-     task "down", sub {
+    task "down", sub {
 
-       my $param = shift;
+      my $param = shift;
 
-       my $box = Rex::Commands::Box->new(name => $param->{name});
-       $box->stop;
-     };
+      my $box = Rex::Commands::Box->new( name => $param->{name} );
+      $box->stop;
+    };
 
-     task "install_webserver", sub {
-       install "apache2";
-     };
+    task "install_webserver", sub {
+      install "apache2";
+    };
 
 -   **auth for** now works with regular expresions.
 
-     # Rexfile
-
-     task foo => sub {
-     };
-     task example => sub {
-     };
-     task example2 => sub {
-     };
-
-      set auth for qr{^example\d$} =>
-         user => "example",
-         password => "foob4r";
+        # Rexfile
+    
+        task foo => sub {
+        };
+        task example => sub {
+        };
+        task example2 => sub {
+        };
+    
+        set auth for qr{^example\d$} => user => "example",
+          password => "foob4r";
 
 -   It is now possible to use the **repository** function for multiple distributions.
 
-     task "add-repo", "server1", "server2", sub {
-       repository add => myrepo => {
-          Ubuntu => {
-             url => "http://foo.bar/repo",
-             distro => "precise",
-             repository => "foo",
-          },
-          Debian => {
-             url => "http://foo.bar/repo",
-             distro => "squeeze",
-             repository => "foo",
-          },
-          CentOS => {
-             url => "http://foo.bar/repo",
-          },
-       };
-     };
+        task "add-repo", "server1", "server2", sub {
+          repository add => myrepo => {
+            Ubuntu => {
+              url        => "http://foo.bar/repo",
+              distro     => "precise",
+              repository => "foo",
+            },
+            Debian => {
+              url        => "http://foo.bar/repo",
+              distro     => "squeeze",
+              repository => "foo",
+            },
+            CentOS => {
+              url => "http://foo.bar/repo",
+            },
+          };
+        };
 
 The key that is used is the return value of **get\_operating\_system()**.
 
 It is also possible to add an **after** hook like this:
 
-     task "add-repo", "server1", "server2", sub {
-       repository add => myrepo => {
-          Ubuntu => {
-             url => "http://foo.bar/repo",
-             distro => "precise",
-             repository => "foo",
-             after => sub {
-                  # import gpg key
-             },
+    task "add-repo", "server1", "server2", sub {
+      repository add => myrepo => {
+        Ubuntu => {
+          url        => "http://foo.bar/repo",
+          distro     => "precise",
+          repository => "foo",
+          after      => sub {
+
+            # import gpg key
           },
-          Debian => {
-             url => "http://foo.bar/repo",
-             distro => "squeeze",
-             repository => "foo",
-             after => sub {
-                  # import gpg key
-             },
+        },
+        Debian => {
+          url        => "http://foo.bar/repo",
+          distro     => "squeeze",
+          repository => "foo",
+          after      => sub {
+
+            # import gpg key
           },
-          CentOS => {
-             url => "http://foo.bar/repo",
-             after => sub {
-                  # import gpg key
-             },
+        },
+        CentOS => {
+          url   => "http://foo.bar/repo",
+          after => sub {
+
+            # import gpg key
           },
-       };
-     };
+        },
+      };
+    };
 
 -   Fixed API usage of Rex
 

--- a/content/docs/release_notes/0.36.md
+++ b/content/docs/release_notes/0.36.md
@@ -24,36 +24,36 @@ You can download OpenNebula module with the following command:
     cloud_region "http://172.16.120.131:2633/RPC2";
 
     task "list-os", sub {
-       print Dumper get_cloud_operating_systems;
+      print Dumper get_cloud_operating_systems;
     };
 
     task "create", sub {
-       my $params = shift;
-       my $vm = cloud_instance create => {
-          image        => "template-1",
-          name         => $params->{name},
-       };
+      my $params = shift;
+      my $vm     = cloud_instance create => {
+        image => "template-1",
+        name  => $params->{name},
+      };
 
-       print Dumper($vm);
+      print Dumper($vm);
     };
 
     task "start", sub {
-       my $params = shift;
-       cloud_instance start => $params->{name};
+      my $params = shift;
+      cloud_instance start => $params->{name};
     };
 
     task "stop", sub {
-       my $params = shift;
-       cloud_instance stop => $params->{name};
+      my $params = shift;
+      cloud_instance stop => $params->{name};
     };
 
     task "terminate", sub {
-       my $params = shift;
-       cloud_instance terminate => $params->{name};
+      my $params = shift;
+      cloud_instance terminate => $params->{name};
     };
 
     task "list", sub {
-       print Dumper cloud_instance_list;
+      print Dumper cloud_instance_list;
     };
 
 -   New function: run\_task
@@ -61,12 +61,14 @@ You can download OpenNebula module with the following command:
 With this function you can run a specific task on a given host and get the output as a return value.
 
     task "prepare", "server5", sub {
-       # do something
-       my $free_mem = run_task "get_free_mem", on => "server3";
-       if($free_mem < 100) {
-          say "Less than 100 MB free mem on server3";
-          # create a new server instance on server5 to unload server3
-       }
+
+      # do something
+      my $free_mem = run_task "get_free_mem", on => "server3";
+      if ( $free_mem < 100 ) {
+        say "Less than 100 MB free mem on server3";
+
+        # create a new server instance on server5 to unload server3
+      }
     };
 
     task "get_free_mem", sub {

--- a/content/docs/release_notes/0.36.md
+++ b/content/docs/release_notes/0.36.md
@@ -8,11 +8,7 @@ title: Release notes for 0.36
 
 You can download OpenNebula module with the following command:
 
-Copy to clipboard
-
     bash# rexify --use Rex::Cloud::OpenNebula
-
-Copy to clipboard
 
     use strict;
     use warnings;
@@ -63,8 +59,6 @@ Copy to clipboard
 -   New function: run\_task
 
 With this function you can run a specific task on a given host and get the output as a return value.
-
-Copy to clipboard
 
     task "prepare", "server5", sub {
        # do something

--- a/content/docs/release_notes/0.37.md
+++ b/content/docs/release_notes/0.37.md
@@ -12,15 +12,11 @@ With this plugin it is possible to call Rex tasks from within Eclipse. See the [
 
 You can use thise module by installing it via *rexify*.
 
-Copy to clipboard
-
     # From within a project
     bash# rexify --use=Rex::DNS:Bind
 
     # To create a new project
     bash# rexify mynewproject --use=Rex::DNS::Bind
-
-Copy to clipboard
 
     set dns => {
           server => "127.0.0.1",
@@ -48,8 +44,6 @@ Copy to clipboard
 See [Rex::DNS::Bind](http://modules.rexify.org/module/Rex::DNS::Bind) for the API documentation.
 
 -   run\_task now accepts additional parameters for tasks (note: it will overwrite CLI parameters)
-
-Copy to clipboard
 
     task "taskone", sub {
        run_task "tasktwo", on => "foo", params => { key1 => "value1", key2 => "value2" };

--- a/content/docs/release_notes/0.37.md
+++ b/content/docs/release_notes/0.37.md
@@ -19,40 +19,42 @@ You can use thise module by installing it via *rexify*.
     bash# rexify mynewproject --use=Rex::DNS::Bind
 
     set dns => {
-          server => "127.0.0.1",
-          key_name => "mysuperkey",
-          key => "/foobar==",
+      server   => "127.0.0.1",
+      key_name => "mysuperkey",
+      key      => "/foobar==",
     };
 
     task sometask => sub {
-        Rex::DNS::Bind::add_record(
-          domain => "rexify.org",
-          host   => "foobar01",
-          data   => "127.0.0.4",
-        );
+      Rex::DNS::Bind::add_record(
+        domain => "rexify.org",
+        host   => "foobar01",
+        data   => "127.0.0.4",
+      );
 
-        Rex::DNS::Bind::delete_record(
-          domain => "rexify.org",
-          host   => "foobar01",
-          type   => "A",
-        );
+      Rex::DNS::Bind::delete_record(
+        domain => "rexify.org",
+        host   => "foobar01",
+        type   => "A",
+      );
 
-        my @entries = Rex::DNS::Bind::list_entries(domain => "rexify.org");
-        print Dumper(\@entries);
+      my @entries = Rex::DNS::Bind::list_entries( domain => "rexify.org" );
+      print Dumper( \@entries );
     };
 
 See [Rex::DNS::Bind](http://modules.rexify.org/module/Rex::DNS::Bind) for the API documentation.
 
 -   run\_task now accepts additional parameters for tasks (note: it will overwrite CLI parameters)
 
-    task "taskone", sub {
-       run_task "tasktwo", on => "foo", params => { key1 => "value1", key2 => "value2" };
-    };
-
-    task "tasktwo", sub {
-       my $param = shift;
-       print Dumper($param);
-    };
+        task "taskone", sub {
+          run_task "tasktwo",
+            on     => "foo",
+            params => { key1 => "value1", key2 => "value2" };
+        };
+    
+        task "tasktwo", sub {
+          my $param = shift;
+          print Dumper($param);
+        };
 
 -   Code changes for better extendability of core functions.
 -   Hardware module is now pluggable

--- a/content/docs/release_notes/0.38.md
+++ b/content/docs/release_notes/0.38.md
@@ -6,8 +6,6 @@ title: Release notes for 0.38
 
 -   added possibility to use local files as templates for rexify command
 
-Copy to clipboard
-
     bash# rexify MyProject --template=/mytemplates/foo.tpl
 
 -   jorisd updated and fixed documentation
@@ -20,8 +18,6 @@ Copy to clipboard
 
 -   Added update\_system command to update a complete system.
 
-Copy to clipboard
-
     task "update_all", "server1", sub {
         update_package_db;
         update_system;
@@ -31,19 +27,13 @@ Copy to clipboard
 
 -   new function to get a server group out of box names
 
-Copy to clipboard
-
     group foo => map { $_->{name} } list_boxes;
 
 -   Amazon support for Rex/Boxes
 
 -   Possibility to describe your Rex/Boxes via a YAML file. So that you don't need to alter your Rexfile if you want to change the Box provider (for example to switch from VirtualBox to Amazon).
 
-Copy to clipboard
-
     use Rex::Commands::Box init_file => "file.yml";
-
-Copy to clipboard
 
     type: VBox
     vms:
@@ -61,8 +51,6 @@ Copy to clipboard
                 type: bridged
                 bridge: en1: Wi-Fi (AirPort)
           setup: setup_db
-
-Copy to clipboard
 
     type: amazon
     amazon:
@@ -84,8 +72,6 @@ Copy to clipboard
           setup: setup_db
 
 -   A new function to control boxes.
-
-Copy to clipboard
 
     task "prepare_boxes", sub {
        # this will create a defined boxes from the YAML file.

--- a/content/docs/release_notes/0.38.md
+++ b/content/docs/release_notes/0.38.md
@@ -18,73 +18,74 @@ title: Release notes for 0.38
 
 -   Added update\_system command to update a complete system.
 
-    task "update_all", "server1", sub {
-        update_package_db;
-        update_system;
-    };
+        task "update_all", "server1", sub {
+          update_package_db;
+          update_system;
+        };
 
 # Boxes
 
 -   new function to get a server group out of box names
 
-    group foo => map { $_->{name} } list_boxes;
+        group foo => map { $_->{name} } list_boxes;
 
 -   Amazon support for Rex/Boxes
 
 -   Possibility to describe your Rex/Boxes via a YAML file. So that you don't need to alter your Rexfile if you want to change the Box provider (for example to switch from VirtualBox to Amazon).
 
-    use Rex::Commands::Box init_file => "file.yml";
+        use Rex::Commands::Box init_file => "file.yml";
 
-    type: VBox
-    vms:
-       fe01:
-          url: http://box.rexify.org/box/ubuntu-server-12.10-amd64.ova
-          network:
-             1:
-                type: bridged
-                bridge: en1: Wi-Fi (AirPort)
-          setup: setup_frontend
-       db01:
-          url: http://box.rexify.org/box/ubuntu-server-12.10-amd64.ova
-          network:
-             1:
-                type: bridged
-                bridge: en1: Wi-Fi (AirPort)
-          setup: setup_db
-
-    type: amazon
-    amazon:
-       access_key: {{access-key}}
-       private_access_key: {{private-access-key}}
-       region: ec2.eu-west-1.amazonaws.com
-       zone: eu-west-1a
-       auth_key: default
-    vms:
-       fe01:
-          ami: ami-c1aaabb5
-          type: m1.large
-          security_group: default
-          setup: setup_frontend
-       db01:
-          ami: ami-c1aaabb5
-          type: m1.large
-          security_group: default
-          setup: setup_db
+        type: VBox
+        vms:
+           fe01:
+              url: http://box.rexify.org/box/ubuntu-server-12.10-amd64.ova
+              network:
+                 1:
+                    type: bridged
+                    bridge: en1: Wi-Fi (AirPort)
+              setup: setup_frontend
+           db01:
+              url: http://box.rexify.org/box/ubuntu-server-12.10-amd64.ova
+              network:
+                 1:
+                    type: bridged
+                    bridge: en1: Wi-Fi (AirPort)
+              setup: setup_db
+    
+        type: amazon
+        amazon:
+           access_key: {{access-key}}
+           private_access_key: {{private-access-key}}
+           region: ec2.eu-west-1.amazonaws.com
+           zone: eu-west-1a
+           auth_key: default
+        vms:
+           fe01:
+              ami: ami-c1aaabb5
+              type: m1.large
+              security_group: default
+              setup: setup_frontend
+           db01:
+              ami: ami-c1aaabb5
+              type: m1.large
+              security_group: default
+              setup: setup_db
 
 -   A new function to control boxes.
 
-    task "prepare_boxes", sub {
-       # this will create a defined boxes from the YAML file.
-       boxes "init";
-    };
+        task "prepare_boxes", sub {
 
-    task "stop_boxes", sub {
-       boxes stop => qw/box1 box2/;
-    };
+          # this will create a defined boxes from the YAML file.
+          boxes "init";
+        };
 
-    task "start_boxes", sub {
-       boxes start => qw/box1 box2/;
-    };
+        task "stop_boxes", sub {
+          boxes stop => qw/box1 box2/;
+        };
+
+        task "start_boxes", sub {
+          boxes start => qw/box1 box2/;
+        };
 
 # Cloud
 

--- a/content/docs/release_notes/0.39.md
+++ b/content/docs/release_notes/0.39.md
@@ -6,13 +6,9 @@ title: Release notes for 0.39
 
 -   New feature flag: **exit\_status**. This will return a non-zero value on exit of rex if a task failed.
 
-Copy to clipboard
-
     use Rex -feature => qw/exit_status/;
 
 -   rexify command now supports private module servers via a configuration file in $HOME/.rex/config.yml
-
-Copy to clipboard
 
     module_server:
        search: http://modules.rexify.org/api/0.39/get/recipes
@@ -26,8 +22,6 @@ Copy to clipboard
 It supports basic authentication. If you don't need authentication you can omit username, password and realm.
 
 -   Added new function is\_installed() to check if a package is already installed on a system.
-
-Copy to clipboard
 
     task "checkit", "server1", sub {
        if(is_installed("vim")) {

--- a/content/docs/release_notes/0.39.md
+++ b/content/docs/release_notes/0.39.md
@@ -10,24 +10,24 @@ title: Release notes for 0.39
 
 -   rexify command now supports private module servers via a configuration file in $HOME/.rex/config.yml
 
-    module_server:
-       search: http://modules.rexify.org/api/0.39/get/recipes
-       recipes: http://modules.rexify.org/api/0.39/get/mod/%s
-       dependencies: http://modules.rexify.org/api/0.39/get/dep/%s
-       perl_dependencies: http://modules.rexify.org/api/0.39/get/perldep/%s
-       username: user
-       password: password
-       realm: authentication-realm
+        module_server:
+           search: http://modules.rexify.org/api/0.39/get/recipes
+           recipes: http://modules.rexify.org/api/0.39/get/mod/%s
+           dependencies: http://modules.rexify.org/api/0.39/get/dep/%s
+           perl_dependencies: http://modules.rexify.org/api/0.39/get/perldep/%s
+           username: user
+           password: password
+           realm: authentication-realm
 
 It supports basic authentication. If you don't need authentication you can omit username, password and realm.
 
 -   Added new function is\_installed() to check if a package is already installed on a system.
 
-    task "checkit", "server1", sub {
-       if(is_installed("vim")) {
-           say "vim is already installed.";
-       }
-    };
+        task "checkit", "server1", sub {
+          if ( is_installed("vim") ) {
+            say "vim is already installed.";
+          }
+        };
 
 -   fixed bugs
 

--- a/content/docs/release_notes/0.4.md
+++ b/content/docs/release_notes/0.4.md
@@ -8,66 +8,63 @@ title: Release notes for 0.4
 
     Now you can get information of the servers hardware and configuration.
 
-         use Rex::Hardware;
-         use Data::Dumper;
+        use Rex::Hardware;
+        use Data::Dumper;
 
-         desc "Get Hardware Information";
-         task "hw-info", "testsystem", sub {
-             my %hw = Rex::Hardware->get( qw/ Host Kernel Memory Network Swap / );
+        desc "Get Hardware Information";
+        task "hw-info", "testsystem", sub {
+          my %hw = Rex::Hardware->get(qw/ Host Kernel Memory Network Swap /);
 
-             print Dumper(\%hw);
-         };
+          print Dumper( \%hw );
+        };
 
     Will produce the following example output:
 
-         $VAR1 = {
-                  'Network' => {
-                                 'networkdevices' => [
-                                                       'eth0',
-                                                       'wlan0'
-                                                     ],
-                                 'networkconfiguration' => {
-                                                             'wlan0' => {
-                                                                          'broadcast' => '192.168.2.255',
-                                                                          'ip' => '192.168.2.229',
-                                                                          'netmask' => '255.255.255.0',
-                                                                          'mac' => '00:21:5C:5C:1E:5F'
-                                                                        },
-                                                             'eth0' => {
-                                                                         'broadcast' => undef,
-                                                                         'ip' => undef,
-                                                                         'netmask' => undef,
-                                                                         'mac' => '00:1C:25:94:B0:85'
-                                                                       }
-                                                           }
-                               },
-                  'Memory' => {
-                                'shared' => '0',
-                                'buffers' => '36',
-                                'free' => '3168',
-                                'used' => '792',
-                                'total' => '3961',
-                                'cached' => '407'
-                              },
-                  'Kernel' => {
-                                'kernelversion' => '#1 SMP PREEMPT 2011-02-21 10:34:10 +0100',
-                                'architecture' => 'x86_64',
-                                'kernel' => 'Linux',
-                                'kernelrelease' => '2.6.37.1-1.2-desktop'
-                              },
-                  'Swap' => {
-                              'free' => '3812',
-                              'used' => '0',
-                              'total' => '3812'
-                            },
-                  'Host' => {
-                              'domain' => 'site',
-                              'manufacturer' => 'LENOVO',
-                              'hostname' => 'linux-ymf0.site',
-                              'operatingsystemrelease' => '11.4',
-                              'operatingsystem' => 'SuSE'
-                            }
-                };
+        $VAR1 = {
+          'Network' => {
+            'networkdevices'       => [ 'eth0', 'wlan0' ],
+            'networkconfiguration' => {
+              'wlan0' => {
+                'broadcast' => '192.168.2.255',
+                'ip'        => '192.168.2.229',
+                'netmask'   => '255.255.255.0',
+                'mac'       => '00:21:5C:5C:1E:5F'
+              },
+              'eth0' => {
+                'broadcast' => undef,
+                'ip'        => undef,
+                'netmask'   => undef,
+                'mac'       => '00:1C:25:94:B0:85'
+              }
+            }
+          },
+          'Memory' => {
+            'shared'  => '0',
+            'buffers' => '36',
+            'free'    => '3168',
+            'used'    => '792',
+            'total'   => '3961',
+            'cached'  => '407'
+          },
+          'Kernel' => {
+            'kernelversion' => '#1 SMP PREEMPT 2011-02-21 10:34:10 +0100',
+            'architecture'  => 'x86_64',
+            'kernel'        => 'Linux',
+            'kernelrelease' => '2.6.37.1-1.2-desktop'
+          },
+          'Swap' => {
+            'free'  => '3812',
+            'used'  => '0',
+            'total' => '3812'
+          },
+          'Host' => {
+            'domain'                 => 'site',
+            'manufacturer'           => 'LENOVO',
+            'hostname'               => 'linux-ymf0.site',
+            'operatingsystemrelease' => '11.4',
+            'operatingsystem'        => 'SuSE'
+          }
+        };
 
 -   **Install Packages**
 
@@ -75,38 +72,40 @@ title: Release notes for 0.4
 
     Example:
 
-         # include for ,,install'' Function
-         use Rex::Commands::Pkg;
+        # include for ,,install'' Function
+        use Rex::Commands::Pkg;
 
-         # include for ,,operating_system_is'' Function
-         use Rex::Commands::Gather;
+        # include for ,,operating_system_is'' Function
+        use Rex::Commands::Gather;
 
-         user "root";
-         
-         private_key "/Users/jan/.ssh/id_rsa";
-         public_key  "/Users/jan/.ssh/is_rsa.pub";
+        user "root";
 
-         # group servers
-         group "test" => "debian01", "centos01", "suse01";
+        private_key "/Users/jan/.ssh/id_rsa";
+        public_key "/Users/jan/.ssh/is_rsa.pub";
 
-         # run tasks in parallel
-         parallelism 2;
+        # group servers
+        group "test" => "debian01", "centos01", "suse01";
 
-         desc "Prepare System";
-         task "prepare", group => "test", sub {
+        # run tasks in parallel
+        parallelism 2;
 
-            # check if operating system is CentOS, because on CentOS vim is 
-            # available through the package "vim-enhanced".
-            if (operating_system_is("CentOS")) {
-                install package => "vim-enhanced";
-            }
-            else {
-                install package => "vim";
-            }
+        desc "Prepare System";
+        task "prepare",
+          group => "test",
+          sub {
 
-            install package => "mc";
+          # check if operating system is CentOS, because on CentOS vim is
+          # available through the package "vim-enhanced".
+          if ( operating_system_is("CentOS") ) {
+            install package => "vim-enhanced";
+          }
+          else {
+            install package => "vim";
+          }
 
-         };
+          install package => "mc";
+
+          };
 
     This task will install *vim* and *mc* on all the 3 systems.
 

--- a/content/docs/release_notes/0.4.md
+++ b/content/docs/release_notes/0.4.md
@@ -8,8 +8,6 @@ title: Release notes for 0.4
 
     Now you can get information of the servers hardware and configuration.
 
-    Copy to clipboard
-
          use Rex::Hardware;
          use Data::Dumper;
 
@@ -21,8 +19,6 @@ title: Release notes for 0.4
          };
 
     Will produce the following example output:
-
-    Copy to clipboard
 
          $VAR1 = {
                   'Network' => {
@@ -78,8 +74,6 @@ title: Release notes for 0.4
     Support for apt, yum and zypper (OpenSuSE)
 
     Example:
-
-    Copy to clipboard
 
          # include for ,,install'' Function
          use Rex::Commands::Pkg;

--- a/content/docs/release_notes/0.40.md
+++ b/content/docs/release_notes/0.40.md
@@ -8,8 +8,6 @@ title: Release notes for 0.40
 
 The first CMDB module is based on YAML files. With this change there will be also a default environment under which rex runs. The default environment is named \* drum roll \* "default".
 
-Copy to clipboard
-
     use Cwd 'getcwd';
     use Rex::CMDB;
 
@@ -35,8 +33,6 @@ If it find the value for "vhosts" in one of these files, it will return that val
 
 It is now possible to use VirtualBox in headless mode on MacOSX and Linux.
 
-Copy to clipboard
-
     set  virtualization => { 
        type => "VBox",
        headless => TRUE
@@ -47,8 +43,6 @@ Copy to clipboard
     };
 
 If you're using Rex/Boxes you can set this option in your YAML file.
-
-Copy to clipboard
 
     type: VBox
     vbox:
@@ -65,8 +59,6 @@ Copy to clipboard
 ## INI style group files
 
 From Franky Van Liedekerke.
-
-Copy to clipboard
 
     ; my group file
     [frontends]
@@ -87,8 +79,6 @@ Copy to clipboard
     [db]
     db[01..02]
 
-Copy to clipboard
-
     use Rex::Group::Lookup::INI;
 
     groups_file "file.ini";
@@ -98,8 +88,6 @@ Copy to clipboard
 There is a new setting called source\_global\_profile. This will source /etc/profile before every run() command.
 
 On some systems this is needed because the user's profile (.bashrc, .bash\_profile) doesn't source the global file. Before you use this function consider changing your .bashrc.
-
-Copy to clipboard
 
     source_global_profile TRUE;
 

--- a/content/docs/release_notes/0.40.md
+++ b/content/docs/release_notes/0.40.md
@@ -12,12 +12,12 @@ The first CMDB module is based on YAML files. With this change there will be als
     use Rex::CMDB;
 
     set cmdb => {
-       type => "YAML",
-       path => getcwd() . "/cmdb",
+      type => "YAML",
+      path => getcwd() . "/cmdb",
     };
 
     task "prepare", sub {
-       my $vhosts = get cmdb "vhosts";
+      my $vhosts = get cmdb "vhosts";
     };
 
 This will search the given cmdb path for the following files (in the named order):
@@ -33,13 +33,13 @@ If it find the value for "vhosts" in one of these files, it will return that val
 
 It is now possible to use VirtualBox in headless mode on MacOSX and Linux.
 
-    set  virtualization => { 
-       type => "VBox",
-       headless => TRUE
+    set virtualization => {
+      type     => "VBox",
+      headless => TRUE
     };
 
     task "foo", sub {
-        vm start => "myvm";
+      vm start => "myvm";
     };
 
 If you're using Rex/Boxes you can set this option in your YAML file.

--- a/content/docs/release_notes/0.41.md
+++ b/content/docs/release_notes/0.41.md
@@ -6,16 +6,12 @@ title: Release notes for 0.41
 
 -   Function to get the last output of a command that uses run() \#104
 
-Copy to clipboard
-
     task "prepare", "mysystem01", sub {
         install "ntp";
         say last_command_output;
     };
 
 -   Refactored Cron module, added environment variable support to cron
-
-Copy to clipboard
 
     task "prepare", "mysystem01", sub {
        my @env = cron env => user => list;
@@ -28,8 +24,6 @@ Copy to clipboard
 -   New sync module
 
 This module doesn't use rsync, so it works with sudo and Windows, too. And it is also possible to use it with templates. If a file should be used as a template, you have to name it somefile.ext.tpl.
-
-Copy to clipboard
 
     task "prepare", "mysystem01", sub {
        # upload directory recursively to remote system. 
@@ -58,15 +52,11 @@ Copy to clipboard
 
 To get a list of all returned information:
 
-Copy to clipboard
-
     use Data::Dumper;
     my %hw_info = Rex::Hardware->get(qw/VirtInfo/);
     print Dumper(\%hw_info);
 
 To get the hypervisor:
-
-Copy to clipboard
 
     task "info", "mysystem01", sub {
        my %hw_info = Rex::Hardware->get(qw/VirtInfo/);
@@ -76,8 +66,6 @@ Copy to clipboard
     };
 
 -   new keyword "case"
-
-Copy to clipboard
 
     task "prepare", "myserver01", sub {
        my $package = case operating_system, {
@@ -105,8 +93,6 @@ Copy to clipboard
 
 -   Cloud/Amazon: support multiple security groups - RenatoCRON
 
-Copy to clipboard
-
        $instance = cloud_instance create => {
                  image_id => "ami-5187bb25",
                  name     => "test01",
@@ -127,8 +113,6 @@ Copy to clipboard
 # Rex/Boxes
 
 -   Creation order of VMs can now be defined in YAML file
-
-Copy to clipboard
 
     type: VBox
     #vbox:

--- a/content/docs/release_notes/0.41.md
+++ b/content/docs/release_notes/0.41.md
@@ -6,46 +6,47 @@ title: Release notes for 0.41
 
 -   Function to get the last output of a command that uses run() \#104
 
-    task "prepare", "mysystem01", sub {
-        install "ntp";
-        say last_command_output;
-    };
+        task "prepare", "mysystem01", sub {
+          install "ntp";
+          say last_command_output;
+        };
 
 -   Refactored Cron module, added environment variable support to cron
 
-    task "prepare", "mysystem01", sub {
-       my @env = cron env => user => list;
-       cron env => user => add => {
-          MYVAR => "foo",
-       };
-       cron env => user => delete => "MYVAR";
-    };
+        task "prepare", "mysystem01", sub {
+          my @env = cron env => user => list;
+          cron env => user => add    => { MYVAR => "foo", };
+          cron env => user => delete => "MYVAR";
+        };
 
 -   New sync module
 
 This module doesn't use rsync, so it works with sudo and Windows, too. And it is also possible to use it with templates. If a file should be used as a template, you have to name it somefile.ext.tpl.
 
     task "prepare", "mysystem01", sub {
-       # upload directory recursively to remote system. 
-       sync_up "/local/directory", "/remote/directory";
 
-       sync_up "/local/directory", "/remote/directory", {
-          # setting custom file permissions for every file
-          files => {
-             owner => "foo",
-             group => "bar",
-             mode  => 600,
-          },
-          # setting custom directory permissions for every directory
-          directories => {
-             owner => "foo",
-             group => "bar",
-             mode  => 700,
-          },
-       };
+      # upload directory recursively to remote system.
+      sync_up "/local/directory", "/remote/directory";
 
-       # download a directory recursively from the remote system to the local machine
-       sync_down "/remote/directory", "/local/directory";
+      sync_up "/local/directory", "/remote/directory", {
+
+        # setting custom file permissions for every file
+        files => {
+          owner => "foo",
+          group => "bar",
+          mode  => 600,
+        },
+
+        # setting custom directory permissions for every directory
+        directories => {
+          owner => "foo",
+          group => "bar",
+          mode  => 700,
+        },
+      };
+
+      # download a directory recursively from the remote system to the local machine
+      sync_down "/remote/directory", "/local/directory";
     };
 
 -   added Hardware::VirtInfo module \#119 - Franky Van Liedekerke
@@ -54,28 +55,28 @@ To get a list of all returned information:
 
     use Data::Dumper;
     my %hw_info = Rex::Hardware->get(qw/VirtInfo/);
-    print Dumper(\%hw_info);
+    print Dumper( \%hw_info );
 
 To get the hypervisor:
 
     task "info", "mysystem01", sub {
-       my %hw_info = Rex::Hardware->get(qw/VirtInfo/);
+      my %hw_info = Rex::Hardware->get(qw/VirtInfo/);
 
-       say "Role: " . $hw_info{VirtInfo}->{virtualization_role};
-       say "Type: " . $hw_info{VirtInfo}->{virtualization_type};
+      say "Role: " . $hw_info{VirtInfo}->{virtualization_role};
+      say "Type: " . $hw_info{VirtInfo}->{virtualization_type};
     };
 
 -   new keyword "case"
 
-    task "prepare", "myserver01", sub {
-       my $package = case operating_system, {
-                         Debian => "vim",
-                         CentOS => "vim-enhanced",
-                         default => "vim",
-                     };
+        task "prepare", "myserver01", sub {
+          my $package = case operating_system, {
+            Debian    => "vim",
+              CentOS  => "vim-enhanced",
+              default => "vim",
+          };
 
-       install $package;
-    };
+          install $package;
+        };
 
 -   Refactored net\_ssh2\_exec() function - Peter H. Ezetta
 
@@ -93,14 +94,14 @@ To get the hypervisor:
 
 -   Cloud/Amazon: support multiple security groups - RenatoCRON
 
-       $instance = cloud_instance create => {
-                 image_id => "ami-5187bb25",
-                 name     => "test01",
-                 key      => "thekey",
-                 zone     => "eu-west-1a",
-                 type     => "m1.large",
-                 security_groups => ["alltcpfoo", "default"],
-              };
+          $instance = cloud_instance create => {
+            image_id        => "ami-5187bb25",
+            name            => "test01",
+            key             => "thekey",
+            zone            => "eu-west-1a",
+            type            => "m1.large",
+            security_groups => [ "alltcpfoo", "default" ],
+          };
 
 # Documentation
 

--- a/content/docs/release_notes/0.42.md
+++ b/content/docs/release_notes/0.42.md
@@ -12,8 +12,6 @@ To use Net::OpenSSH you have to set the connection type in your Rexfile.
 
 This fixes long standing pull request \#70.
 
-Copy to clipboard
-
     use Rex -feature => '0.42';
 
     set connection => 'OpenSSH';
@@ -26,8 +24,6 @@ Copy to clipboard
 
 If you want to use kerberos authentication you have to use Net::OpenSSH.
 
-Copy to clipboard
-
     set connection => "OpenSSH";
 
     user "youruser";
@@ -36,8 +32,6 @@ Copy to clipboard
 #### Custom user for sudo command
 
 It is now possible to use custom users for the sudo command.
-
-Copy to clipboard
 
     task "mytask", "server1", sub {
         sudo {
@@ -49,8 +43,6 @@ Copy to clipboard
 #### new function delete\_lines\_according\_to - liedekef
 
 This function is similar to delete\_lines\_matching but with an other syntax and the possibility to use the on\_change hook if the file was changed.
-
-Copy to clipboard
 
     task "cleanup", "server1", sub {
        delete_lines_according_to qr{^foo:}, "/etc/passwd",
@@ -67,14 +59,10 @@ The INI file feature is improved to allow custom properties for servers and to a
 
 You have to use use\_server\_auth feature flag for this.
 
-Copy to clipboard
-
     # Rexfile
     use Rex -feature => [qw/use_server_auth/];
     use Rex::Group::Lookup::INI;
     groups_file('servergroups.ini');
-
-Copy to clipboard
 
     ; my group file
     [frontends]
@@ -106,8 +94,6 @@ Copy to clipboard
 
 This will create the following groups:
 
-Copy to clipboard
-
     frontends: fe01, fe02, fe03, fe04, fe05
     backends: be01, be02, be04
     db: db01, db02
@@ -116,15 +102,11 @@ Copy to clipboard
 
 memcache02 will use custom authentication and there will be a special option "services" for this server that can be queried like this:
 
-Copy to clipboard
-
     task "mytask", group => "memcache", sub {
         say connection->server->option("services");
     };
 
 #### cwd option for run command
-
-Copy to clipboard
 
     run "ls -l",
        cwd => "/home";

--- a/content/docs/release_notes/0.42.md
+++ b/content/docs/release_notes/0.42.md
@@ -17,7 +17,7 @@ This fixes long standing pull request \#70.
     set connection => 'OpenSSH';
 
     task 'yourtask', 'yourserver', sub {
-       say run 'uptime';
+      say run 'uptime';
     };
 
 #### Kerberos authentication - chenryn
@@ -34,10 +34,10 @@ If you want to use kerberos authentication you have to use Net::OpenSSH.
 It is now possible to use custom users for the sudo command.
 
     task "mytask", "server1", sub {
-        sudo {
-             user => "foo",
-             command => "id",
-        };
+      sudo {
+        user    => "foo",
+        command => "id",
+      };
     };
 
 #### new function delete\_lines\_according\_to - liedekef
@@ -45,10 +45,9 @@ It is now possible to use custom users for the sudo command.
 This function is similar to delete\_lines\_matching but with an other syntax and the possibility to use the on\_change hook if the file was changed.
 
     task "cleanup", "server1", sub {
-       delete_lines_according_to qr{^foo:}, "/etc/passwd",
-          on_change => sub {
-             say "removed user foo.";
-          };
+      delete_lines_according_to qr{^foo:}, "/etc/passwd", on_change => sub {
+        say "removed user foo.";
+      };
     };
 
 #### new feature flag use\_server\_auth to enable auth properties in INI files
@@ -102,14 +101,15 @@ This will create the following groups:
 
 memcache02 will use custom authentication and there will be a special option "services" for this server that can be queried like this:
 
-    task "mytask", group => "memcache", sub {
-        say connection->server->option("services");
-    };
+    task "mytask",
+      group => "memcache",
+      sub {
+      say connection->server->option("services");
+      };
 
 #### cwd option for run command
 
-    run "ls -l",
-       cwd => "/home";
+    run "ls -l", cwd => "/home";
 
 ### Speed improvements
 

--- a/content/docs/release_notes/0.43.md
+++ b/content/docs/release_notes/0.43.md
@@ -41,7 +41,7 @@ Or, within the *Rexfile*
 The YAML report will be created inside a directory called *report*. If you want to use a different directory you can set it with a special variable.
 
     use Rex -base;
-    report -on => "YAML";
+    report -on      => "YAML";
     set report_path => "/path/to/";
 
 It is also possible to create custom reporting classes. Just take a look at [Rex::Report::RexIO](https://github.com/RexIO/rex-io-reports/blob/master/rex/lib/Rex/Report/RexIO.pm).
@@ -83,16 +83,16 @@ rex will now only upload a file if it really changes and it will upload the file
 
 -   setting options for OpenSSH connection mode
 
-    Rex::Config->set_openssh_opt(StrictHostKeyChecking => "no");
+        Rex::Config->set_openssh_opt( StrictHostKeyChecking => "no" );
 
 -   set temporary directory - \#166
 
-    user "foo";
-    password "b4r";
-    tmp_dir "/home/foo/tmp";
+        user "foo";
+        password "b4r";
+        tmp_dir "/home/foo/tmp";
 
-    task "mytask", "myserver", sub {
-    };
+        task "mytask", "myserver", sub {
+        };
 
 -   if a given feature flag isn't supported, Rex will now die() - \#177
 

--- a/content/docs/release_notes/0.43.md
+++ b/content/docs/release_notes/0.43.md
@@ -8,15 +8,11 @@ title: Release notes for 0.43
 
 If you want to cache the inventory and to use this cache for subsequent rex calls, you can use the *REX\_CACHE\_TYPE* environment variable.
 
-Copy to clipboard
-
     REX_CACHE_TYPE=YAML rex $task
 
 This will create a folder ".cache" and creates a separate cache file for each host. If you want to use a different folder you can set it in the *REX\_CACHE\_PATH* environment variable.
 
 You can also set the cache type inside your *Rexfile*
-
-Copy to clipboard
 
     # Rexfile
 
@@ -34,21 +30,15 @@ Currently not every Rex function gets monitored by this feature, but all importa
 
 To activate the reporting you can use the *REX\_REPORT\_TYPE* environment variable or use the *reporting* feature inside your *Rexfile*.
 
-Copy to clipboard
-
     REX_REPORT_TYPE=YAML rex the-task
 
 Or, within the *Rexfile*
-
-Copy to clipboard
 
     # Rexfile
     use Rex -base;
     report -on => "YAML";
 
 The YAML report will be created inside a directory called *report*. If you want to use a different directory you can set it with a special variable.
-
-Copy to clipboard
 
     use Rex -base;
     report -on => "YAML";
@@ -64,8 +54,6 @@ You can test these scripts by checking out the [krimdomu/rex-shell-extension](ht
 
 Login to fe01.my.lan and execute uptime
 
-Copy to clipboard
-
     #!/bin/bash
     export REX_REMOTE_HOST="fe01.my.lan"
     GROUPS=$(rex-run "id -Gn www-data")
@@ -74,8 +62,6 @@ Copy to clipboard
     done
 
 Login to fe01.my.lan, testing if /etc/sudoers is there, and if not, install package and upload a template sudoers file
-
-Copy to clipboard
 
     #!/bin/bash
     export REX_REMOTE_HOST="fe01.my.lan"
@@ -97,13 +83,9 @@ rex will now only upload a file if it really changes and it will upload the file
 
 -   setting options for OpenSSH connection mode
 
-Copy to clipboard
-
     Rex::Config->set_openssh_opt(StrictHostKeyChecking => "no");
 
 -   set temporary directory - \#166
-
-Copy to clipboard
 
     user "foo";
     password "b4r";

--- a/content/docs/release_notes/0.44.md
+++ b/content/docs/release_notes/0.44.md
@@ -8,8 +8,6 @@ title: Release notes for 0.44
 
 -   Format the output of say() - \#155
 
-Copy to clipboard
-
     sayformat '%h: %s';
 
     task "test", sub {
@@ -25,8 +23,6 @@ Possible formatting options:
 
 -   user-defined columns for ps() command - \#175 - dirkcjelli
 
-Copy to clipboard
-
     task "ps", "server01", sub {
        my @list = grep { $_->{"ni"} == -5 } ps("command","ni");
     };
@@ -39,8 +35,6 @@ Copy to clipboard
 
 -   run\_batch() command to run batches on demand - \#222 - jorisd
 
-Copy to clipboard
-
     my @return = run_batch "batchname", on => "192.168.3.56";
 
 -   Allow "sed" function to work on multiple lines. - \#227 - davidolrik, krimdomu
@@ -52,8 +46,6 @@ Copy to clipboard
 -   Added some hooks at central points in rex, so that it is possible to control the behaviour of rex in some points.
 
 For example:
-
-Copy to clipboard
 
     use Rex::Hook;
     use Data::Dumper;
@@ -82,8 +74,6 @@ Copy to clipboard
 
 -   added on\_change hook for sync\_up and sync\_down - \#232
 
-Copy to clipboard
-
     sync_up "files/", "/remote/folder", {
        on_change => sub {
           my (@changed_files) = @_;
@@ -92,8 +82,6 @@ Copy to clipboard
     };
 
 -   Rex::Group::Lookup::Command - read hostnames from a command. - \#233 - fanyeren
-
-Copy to clipboard
 
     group "dbserver"   => lookup_command("cat ip.list | grep -v -E '^#'");
 
@@ -105,8 +93,6 @@ Copy to clipboard
 
 -   Make ssh read buffer configurable (for Net::SSH2 connections) - \#247. This will speedup the connection, but may break on older systems!
 
-Copy to clipboard
-
     set rex_internals => {
        read_buffer_size => 2000,
     };
@@ -117,16 +103,12 @@ Copy to clipboard
 
 -   feature flag to deactivate path cleanup - \#261
 
-Copy to clipboard
-
     # Rexfile
     use Rex -feature => ['no_path_cleanup'];
 
     task prepare => sub {};
 
 -   feature flag to parse $HOME/.profile - \#262
-
-Copy to clipboard
 
     # Rexfile
     use Rex -feature => ['source_profile'];
@@ -136,8 +118,6 @@ Copy to clipboard
 -   Cloud::Amazon: check to make sure it is HASH before key look up - \#263 - oneness
 
 -   autodie feature if run() fail - \#265
-
-Copy to clipboard
 
     # Rexfile
     use Rex -feature => ['exec_autodie'];
@@ -179,8 +159,6 @@ Copy to clipboard
 -   Rex::Ext::Crypt - encrypt strings inside a Rexfile.
 
 -   Rex::Ext::Backup - a simple backup module. This module creates a backup of a file before rex changes it.
-
-Copy to clipboard
 
      include qw/Rex::Ext::Backup/;
 

--- a/content/docs/release_notes/0.44.md
+++ b/content/docs/release_notes/0.44.md
@@ -8,11 +8,11 @@ title: Release notes for 0.44
 
 -   Format the output of say() - \#155
 
-    sayformat '%h: %s';
+        sayformat '%h: %s';
 
-    task "test", sub {
-       say "hello world";
-    };
+        task "test", sub {
+          say "hello world";
+        };
 
 Possible formatting options:
 
@@ -23,9 +23,9 @@ Possible formatting options:
 
 -   user-defined columns for ps() command - \#175 - dirkcjelli
 
-    task "ps", "server01", sub {
-       my @list = grep { $_->{"ni"} == -5 } ps("command","ni");
-    };
+        task "ps", "server01", sub {
+          my @list = grep { $_->{"ni"} == -5 } ps( "command", "ni" );
+        };
 
 -   using tilde (~) sign for directories - \#198 - Gnouc, Krimdomu
 
@@ -35,7 +35,7 @@ Possible formatting options:
 
 -   run\_batch() command to run batches on demand - \#222 - jorisd
 
-    my @return = run_batch "batchname", on => "192.168.3.56";
+        my @return = run_batch "batchname", on => "192.168.3.56";
 
 -   Allow "sed" function to work on multiple lines. - \#227 - davidolrik, krimdomu
 
@@ -51,39 +51,40 @@ For example:
     use Data::Dumper;
 
     register_function_hooks {
-       before => {
-          file => sub {
-             print Dumper(\@_);
-             print "before file\n";
-             return;
-          },
-          create_user => sub {
-             print "before create_user\n";
-             die;
-          },
-       },
-       after => {
-          file => sub {
-             print "after file\n";
-          },
-          create_user => sub {
-             print "after create_user\n";
-          },
-       }
+      before => {
+        file => sub {
+          print Dumper( \@_ );
+          print "before file\n";
+          return;
+        },
+        create_user => sub {
+          print "before create_user\n";
+          die;
+        },
+      },
+      after => {
+        file => sub {
+          print "after file\n";
+        },
+        create_user => sub {
+          print "after create_user\n";
+        },
+      }
     };
 
 -   added on\_change hook for sync\_up and sync\_down - \#232
 
-    sync_up "files/", "/remote/folder", {
-       on_change => sub {
-          my (@changed_files) = @_;
-         # do something
-       };
-    };
+        sync_up "files/", "/remote/folder", {
+          on_change => sub {
+            my (@changed_files) = @_;
+
+            # do something
+          };
+        };
 
 -   Rex::Group::Lookup::Command - read hostnames from a command. - \#233 - fanyeren
 
-    group "dbserver"   => lookup_command("cat ip.list | grep -v -E '^#'");
+        group "dbserver" => lookup_command("cat ip.list | grep -v -E '^#'");
 
 -   Improve user and group management on OpenWrt - \#242 - ferki
 
@@ -93,9 +94,7 @@ For example:
 
 -   Make ssh read buffer configurable (for Net::SSH2 connections) - \#247. This will speedup the connection, but may break on older systems!
 
-    set rex_internals => {
-       read_buffer_size => 2000,
-    };
+        set rex_internals => { read_buffer_size => 2000, };
 
 -   Add systemd service provider support for Gentoo - \#250 - ferki
 
@@ -103,28 +102,28 @@ For example:
 
 -   feature flag to deactivate path cleanup - \#261
 
-    # Rexfile
-    use Rex -feature => ['no_path_cleanup'];
+        # Rexfile
+        use Rex -feature => ['no_path_cleanup'];
 
-    task prepare => sub {};
+        task prepare => sub { };
 
 -   feature flag to parse $HOME/.profile - \#262
 
-    # Rexfile
-    use Rex -feature => ['source_profile'];
+        # Rexfile
+        use Rex -feature => ['source_profile'];
 
-    task prepare => sub {};
+        task prepare => sub { };
 
 -   Cloud::Amazon: check to make sure it is HASH before key look up - \#263 - oneness
 
 -   autodie feature if run() fail - \#265
 
-    # Rexfile
-    use Rex -feature => ['exec_autodie'];
+        # Rexfile
+        use Rex -feature => ['exec_autodie'];
 
-    task "prepare", sub {
-       run "this-command-fails";
-    };
+        task "prepare", sub {
+          run "this-command-fails";
+        };
 
 -   added support for tcsh shell - \#284
 
@@ -160,13 +159,13 @@ For example:
 
 -   Rex::Ext::Backup - a simple backup module. This module creates a backup of a file before rex changes it.
 
-     include qw/Rex::Ext::Backup/;
+        include qw/Rex::Ext::Backup/;
 
-     set backup_location => "backup/%h";
+        set backup_location => "backup/%h";
 
-     task yourtask => sub {
-        file "/etc/foo.conf", content => "new content\n";
-     };
+        task yourtask => sub {
+          file "/etc/foo.conf", content => "new content\n";
+        };
 
 -   Rex::Commands::Pstree - module to run pstree - fanyeren
 

--- a/content/docs/release_notes/0.45.md
+++ b/content/docs/release_notes/0.45.md
@@ -15,9 +15,10 @@ Changes in the Cloud API
     -   Authentication and endpoint.
 
             cloud_service "OpenStack";
-            cloud_auth tenant_name => "tenant",
-                       username    => "user",
-                       password    => "password";
+            cloud_auth
+              tenant_name => "tenant",
+              username    => "user",
+              password    => "password";
             cloud_region "http://openstack.domain.tld:5000/v2.0";
 
     -   Creating volumes and vms.
@@ -34,7 +35,7 @@ Changes in the Cloud API
     -   Terminating an instance and removing the volume.
 
             cloud_instance terminate => $instance->{id};
-            cloud_volume delete => $vol_id;
+            cloud_volume delete      => $vol_id;
 
 -   added cloud\_image\_list() function
 -   added cloud\_network() function to manage cloud networks if the provider supports it
@@ -50,9 +51,9 @@ Changes in the core. These include new resources and new options for existing on
         If this option is set, the file will never be overwritten.
 
             file "/var/named/$zone->{name}.zone",
-              content      => template( '@zone-file.tpl', conf => $conf, %{$zone} ),
-              owner        => "named",
-              group        => "named",
+              content => template( '@zone-file.tpl', conf => $conf, %{$zone} ),
+              owner   => "named",
+              group   => "named",
               no_overwrite => TRUE;
 
     -   ensure directory option for file().
@@ -69,8 +70,10 @@ Changes in the core. These include new resources and new options for existing on
         This allow operations on multiple files without duplicating the code.
 
             file [
-                "/etc/rex/io/inventory/bootdevice", "/etc/rex/io/inventory/bridge",
-                "/etc/rex/io/inventory/sysinfo", "/etc/rex/io/inventory/os"
+              "/etc/rex/io/inventory/bootdevice",
+              "/etc/rex/io/inventory/bridge",
+              "/etc/rex/io/inventory/sysinfo",
+              "/etc/rex/io/inventory/os"
               ],
               owner => "root",
               group => "root",
@@ -94,7 +97,8 @@ Changes in the core. These include new resources and new options for existing on
         This tell Rex that this command creates a special file. If this file is found, the command won't get executed anymore.
 
             run "download-ipxe",
-              command => "wget -O /var/lib/tftpboot/undionly.ipxe http://boot.ipxe.org/undionly.kpxe",
+              command =>
+              "wget -O /var/lib/tftpboot/undionly.ipxe http://boot.ipxe.org/undionly.kpxe",
               creates => "/var/lib/tftpboot/undionly.ipxe";
 
     -   *only\_if* and *unless* option for run() resource.
@@ -102,8 +106,9 @@ Changes in the core. These include new resources and new options for existing on
         This will execute the command only if the command given will execute successfully (or terminate unsuccessfull).
 
             run "add-service-os",
-                command => "mysql -uroot < /tmp/data.sql",
-                unless  => "mysql -uroot dbschema -e 'SELECT id FROM os_template WHERE id=2' | grep -q 2";
+              command => "mysql -uroot < /tmp/data.sql",
+              unless =>
+              "mysql -uroot dbschema -e 'SELECT id FROM os_template WHERE id=2' | grep -q 2";
 
     -   support for customized environments. - \#316 - andrejzverev
 
@@ -111,8 +116,8 @@ Changes in the core. These include new resources and new options for existing on
 
             run "my_command",
               env => {
-                env_var_1 => "the value for 1",
-                env_var_2 => "the value for 2",
+              env_var_1 => "the value for 1",
+              env_var_2 => "the value for 2",
               };
 
 -   Added notifications for *run* and *service*.
@@ -123,27 +128,27 @@ Changes in the core. These include new resources and new options for existing on
 
             # somewhere else in the code
             file "/etc/httpd/httpd.conf",
-              content   => template("templates/httpd.conf.tpl", %vars),
+              content   => template( "templates/httpd.conf.tpl", %vars ),
               on_change => sub { notify service => "httpd"; };
 
 -   *pkg* resource (replacement for install function).
 
-        pkg "vim", ensure => "present";
-        pkg "httpd", ensure => "2.4.6";
+        pkg "vim",      ensure => "present";
+        pkg "httpd",    ensure => "2.4.6";
         pkg "vim-tiny", ensure => "absent";
-        pkg ["tftp-server", "wget"], ensure => "latest";
+        pkg [ "tftp-server", "wget" ], ensure => "latest";
 
 -   Added account() resource (as replacement for create\_user).
 
         account "krimdomu",
-          ensure   => "present",
-          uid      => 509,
-          home     => '/root',
-          comment  => 'User Account',
-          expire   => '2011-05-30',
-          groups   => ['root', '...'],
-          password => 'blahblah',
-          system   => 1,
+          ensure         => "present",
+          uid            => 509,
+          home           => '/root',
+          comment        => 'User Account',
+          expire         => '2011-05-30',
+          groups         => [ 'root', '...' ],
+          password       => 'blahblah',
+          system         => 1,
           no_create_home => TRUE,
           ssh_key        => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChUw...";
 

--- a/content/docs/release_notes/0.46.md
+++ b/content/docs/release_notes/0.46.md
@@ -30,7 +30,7 @@ To create a test just create a new file inside a *t* directory: *t/base.t*.
       $t->name("ubuntu test");
 
       $t->base_vm("http://box.rexify.org/box/ubuntu-server-12.10-amd64.ova");
-      $t->vm_auth(user => "root", password => "box");
+      $t->vm_auth( user => "root", password => "box" );
 
       $t->run_task("setup");
 
@@ -39,10 +39,10 @@ To create a test just create a new file inside a *t* directory: *t/base.t*.
       $t->has_package("unzip");
       $t->has_file("/etc/ntp.conf");
       $t->has_service_running("ntp");
-      $t->has_content("/etc/passwd", qr{root:x:0:}ms);
+      $t->has_content( "/etc/passwd", qr{root:x:0:}ms );
 
       run "ls -l";
-      $t->ok($? == 0, "ls -l returns success.");
+      $t->ok( $? == 0, "ls -l returns success." );
 
       $t->finish;
     };
@@ -63,7 +63,8 @@ With Rex/Boxes you can easily create your test environment with VirtualBox. You 
         #
         # CALL:
         # rex init --name=gpw --url=http://domain.tld/ubuntu-server-12.10-amd64.qcow2
-        desc "Initialize and start the VM: rex init --name=vmname [--url=http://...]";
+        desc
+          "Initialize and start the VM: rex init --name=vmname [--url=http://...]";
         task "init", make {
           my $param = shift;
 
@@ -119,16 +120,17 @@ Changes in the Cloud API
               image_id => "80fbcb55-b206-41f9-9bc2-2dd7aac6c061",
               name     => "myvm01",
               flavor   => "performance1-1",
-              networks => ["a733f9d7-098e-4bf1-881d-5a91e84b44bb"];  # networks is optional
+              networks => ["a733f9d7-098e-4bf1-881d-5a91e84b44bb"]; # networks is optional
             };
 
-            cloud_volume attach => $vol_id,
-                to => $instance>{id};
+            cloud_volume
+              attach => $vol_id,
+              to     => $instance > {id};
 
     -   Terminating an instance and removing the volume.
 
-            cloud_instance terminate => $instance>{id};
-            cloud_volume delete => $vol_id;
+            cloud_instance terminate => $instance > {id};
+            cloud_volume delete      => $vol_id;
 
 -   fixed a case where amazon returns instance item in an array - Kasim Tuman
 -   fixed multiple tags - David Golovan
@@ -144,7 +146,7 @@ Changes in the Cloud API
 -   Allow passing template content to template command - \#345 - reneeb
 
         file "/etc/file.cnf",
-          content => template(\'<%= $name %> is cool!', name => 'Rex');
+          content => template( \'<%= $name %> is cool!', name => 'Rex' );
 
 -   Added 'no\_cache' feature. If you need to disable the cache, use this.
 
@@ -179,7 +181,7 @@ Changes in the Cloud API
 
         # Rexfile
         desc "The live environment";
-        environment live => sub {};
+        environment live => sub { };
 
 -   Added `groups_dbi()` function to generate server groups from sql - \#346 - Jean-Marie RENOUARD
 
@@ -190,7 +192,7 @@ Changes in the Cloud API
 -   Added authentication to download() function. - \#340
 
         download "http://secured.location.tld/foo.tgz", "foo.tgz",
-          user => "httpuser",
+          user     => "httpuser",
           password => "password";
 
 -   Refactored tmp dir generation - FErki

--- a/content/docs/release_notes/0.47.0.md
+++ b/content/docs/release_notes/0.47.0.md
@@ -17,35 +17,36 @@ With Rex::Test it is possible to test your Rexfile on a local VM before executin
 -   Rex::Box now also works with KVM
 
         use Rex::Test::Base;
-            use Data::Dumper;
-            use Rex -base;
+        use Data::Dumper;
+        use Rex -base;
 
-            set box => "KVM";
+        set box => "KVM";
 
-            test {
-              my $t = shift;
+        test {
+          my $t = shift;
 
-              $t->name("ubuntu test");
+          $t->name("ubuntu test");
 
-              $t->base_vm("http://box.rexify.org/box/ubuntu-server-12.10-amd64.img");
-              $t->vm_auth(user => "root", password => "box");
+          $t->base_vm(
+            "http://box.rexify.org/box/ubuntu-server-12.10-amd64.img");
+          $t->vm_auth( user => "root", password => "box" );
 
-              $t->run_task("setup");
+          $t->run_task("setup");
 
-              $t->has_package("vim");
-              $t->has_package("ntp");
-              $t->has_package("unzip");
-              $t->has_file("/etc/ntp.conf");
-              $t->has_service_running("ntp");
-              $t->has_content("/etc/passwd", qr{root:x:0:}ms);
+          $t->has_package("vim");
+          $t->has_package("ntp");
+          $t->has_package("unzip");
+          $t->has_file("/etc/ntp.conf");
+          $t->has_service_running("ntp");
+          $t->has_content( "/etc/passwd", qr{root:x:0:}ms );
 
-              run "ls -l";
-              $t->ok($? == 0, "ls -l returns success.");
+          run "ls -l";
+          $t->ok( $? == 0, "ls -l returns success." );
 
-              $t->finish;
-            };
+          $t->finish;
+        };
 
-            1;
+        1;
 
 ## Base
 
@@ -69,23 +70,27 @@ With Rex::Test it is possible to test your Rexfile on a local VM before executin
 
 -   It is now possible to define **before**, **around** and **after** hooks for all tasks in one namespace with the `ALL` keyword.
 
-        before ALL => sub {}
+        before ALL => sub { }
 
 -   Extended service() resource, so that it is now possible to define what it should do for the different actions.
 
         task "prepare", sub {
-           service "apache2",
-             ensure  => "started",
-             start   => "/usr/local/bin/httpd -f /etc/my/httpd.conf",
-             stop    => "killall httpd",
-             status  => "ps -efww | grep httpd",
-             restart => "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf",
-             reload  => "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf";
-         };
+          service "apache2",
+            ensure => "started",
+            start  => "/usr/local/bin/httpd -f /etc/my/httpd.conf",
+            stop   => "killall httpd",
+            status => "ps -efww | grep httpd",
+            restart =>
+            "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf",
+            reload =>
+            "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf";
+        };
 
 -   Syntax enhancement of **group** command \#369 - Jens Berthold
 
-        group "g1", "srv1" => { user => "other" }, "srv2";
+        group "g1",
+          "srv1" => { user => "other" },
+          "srv2";
 
 -   Package-Management with pkgng on FreeBSD 10
 

--- a/content/docs/release_notes/0.50.0.md
+++ b/content/docs/release_notes/0.50.0.md
@@ -11,7 +11,7 @@ These are the changes in 0.50 release.
     If you need to use a jump-host to connect to your servers, you can now use a proxy command to do so. This feature is only available if you're using the **OpenSSH** connection model.
 
         use Rex -feature => ['0.50'];
-        set connection => "OpenSSH";
+        set connection   => "OpenSSH";
         proxy_command "ssh user@jumphost nc %h %p 2>/dev/null";
 
 -   **Added a new experimental execution model**

--- a/content/docs/release_notes/0.51.2.md
+++ b/content/docs/release_notes/0.51.2.md
@@ -73,10 +73,12 @@ These are the changes in 0.51 release.
 
         use Rex -feature => ['0.51'];
 
-        task "restart_services", group => "redis", make {
+        task "restart_services",
+          group => "redis",
+          make {
           my @services = split /,/, connection->server->services;
-          service [ @services ]  => "restart";
-        };
+          service [@services] => "restart";
+          };
 
      
 

--- a/content/docs/release_notes/0.52.1.md
+++ b/content/docs/release_notes/0.52.1.md
@@ -16,20 +16,18 @@ We welcome any feedback and if you want to help developing this webfrontend feel
 
 -   **on\_change** hook for update\_system
 
-        update_system
-          on_change => sub {
-            my (@modified_packates) = @_;
-              for my $pkg (@modified_packages) {
-                say "Name: $pkg->{name}";
-                say "Version: $pkg->{version}";
-                say "Action: $pkg->{action}";   # some of updated, installed or removed
-              }
-          };
+        update_system on_change => sub {
+          my (@modified_packates) = @_;
+          for my $pkg (@modified_packages) {
+            say "Name: $pkg->{name}";
+            say "Version: $pkg->{version}";
+            say "Action: $pkg->{action}"; # some of updated, installed or removed
+          }
+        };
 
 -   Added support for **end\_if\_matched** option to run command - nathanIL
 
-        run "my_command",
-           end_if_matched => qr/PATTERN/;
+        run "my_command", end_if_matched => qr/PATTERN/;
 
 -   Tie server.ini to specified -E environment (server.$environment.ini). - ehu
 
@@ -38,28 +36,32 @@ We welcome any feedback and if you want to help developing this webfrontend feel
     The before\_task\_start hook will be executed before the fork for the task is made. The after\_task\_finished hook will be executed after all servers has finished the task.
 
         before_task_start mytask => sub {
-           # do some things
+
+          # do some things
         };
         after_task_finished mytask => sub {
-           # do some things
+
+          # do some things
         };
 
 -   Added **fallback authentication** support.
 
     Sometimes you have different authentications on different hosts and you don't know beforehand which one you have to use. For these cases you can now define multiple authentication options. Rex will try all of them.
 
-        auth fallback => {
-           user        => "fallback_user1",
-           password    => "fallback_pw1",
-           public_key  => "",
-           private_key => "",
-        }, {
-           user        => "fallback_user2",
-           password    => "fallback_pw2",
-           public_key  => "keys/public.key",
-           private_key => "keys/private.key",
-           sudo        => TRUE,
-        };
+        auth
+          fallback => {
+          user        => "fallback_user1",
+          password    => "fallback_pw1",
+          public_key  => "",
+          private_key => "",
+          },
+          {
+          user        => "fallback_user2",
+          password    => "fallback_pw2",
+          public_key  => "keys/public.key",
+          private_key => "keys/private.key",
+          sudo        => TRUE,
+          };
 
 ## Cloud
 

--- a/content/docs/release_notes/0.53.1.md
+++ b/content/docs/release_notes/0.53.1.md
@@ -19,7 +19,7 @@ A first version of the Rex::JobControl Webfrontend will also be released in the 
         resource $resource_name,
           option1 => "value1",
           option2 => "value2",
-          ensure => "present, absent, ...";
+          ensure  => "present, absent, ...";
 
     Currently there is only one keyword that every resource have to obey.
 
@@ -35,17 +35,18 @@ A first version of the Rex::JobControl Webfrontend will also be released in the 
         use Rex::Resource::Common;
         resource "motd", sub {
           my ($params) = @_;
-          my $name     = resource_name;
+          my $name = resource_name;
 
-          if($params->{ensure} eq "present") {
+          if ( $params->{ensure} eq "present" ) {
+
             # do some things.
-            if(! is_file($name) ) {
+            if ( !is_file($name) ) {
               file $name, content => $params->{content};
               emit changed;
             }
           }
-          elsif($params->{ensure} eq "absent") {
-            if( is_file($name) ) {
+          elsif ( $params->{ensure} eq "absent" ) {
+            if ( is_file($name) ) {
               rm $name;
               emit changed;
             }
@@ -57,10 +58,11 @@ A first version of the Rex::JobControl Webfrontend will also be released in the 
         use BaseSystem;
         task "setup", sub {
           BaseSystem::motd "/etc/motd",
-            ensure  => present,
-            content => "Hello World.",
-            on_change     => sub {
-              # do something when changed event was triggered
+            ensure    => present,
+            content   => "Hello World.",
+            on_change => sub {
+
+            # do something when changed event was triggered
             };
         };
 

--- a/content/docs/release_notes/0.54.3.md
+++ b/content/docs/release_notes/0.54.3.md
@@ -16,18 +16,18 @@ path\_map is a new feature developed by Erik Huelsmann to ease the management of
 
     set path_map => {
       "files/" => [
-        "files/{environment}/{hostname}/",
-        "files/{environment}/",
+        "files/{environment}/{hostname}/", "files/{environment}/",
         "files/{hostname}/",
       ],
       "templates/" => [
-        "templates/{environment}/{hostname}/",
-        "templates/{environment}/",
+        "templates/{environment}/{hostname}/", "templates/{environment}/",
         "templates/{hostname}/",
       ],
     };
 
-    task "setup", group => "frontends", sub {
+    task "setup",
+      group => "frontends",
+      sub {
       file "/etc/security/access.conf",
         source => "files/etc/security/access.conf",
         owner  => "root",
@@ -39,7 +39,7 @@ path\_map is a new feature developed by Erik Huelsmann to ease the management of
         owner   => "root",
         group   => "root",
         mode    => 644;
-    };
+      };
 
 This example will search for the files it should upload or process as templates in the following direction:
 

--- a/content/docs/release_notes/0.57.0.md
+++ b/content/docs/release_notes/0.57.0.md
@@ -13,10 +13,8 @@ We want to thank every contributor that makes this release possible.
 <!-- -->
 
     task "setup", sub {
-      sync_up "local", "remote", {
-        parse_templates => FALSE,
-      };
-    }
+      sync_up "local", "remote", { parse_templates => FALSE, };
+      }
 
 ## Bugfixes
 

--- a/content/docs/release_notes/0.8.md
+++ b/content/docs/release_notes/0.8.md
@@ -8,8 +8,6 @@ title: Release notes for 0.8
 
     Added chown, chgrp and chmod functions to work transparently over ssh.
 
-    Copy to clipboard
-
          task "change", sub {
              chown "jan", "/home/jan", 
                                recursive => 1;
@@ -25,8 +23,6 @@ title: Release notes for 0.8
 
     Added two functions to manipulate files: delete\_lines\_matching and append\_if\_no\_such\_line.
 
-    Copy to clipboard
-
          task "manip", sub {
             delete_lines_matching "/var/log/auth.log", matching => "root";
             delete_lines_matching "/var/log/auth.log", matching => qr{Failed};
@@ -39,8 +35,6 @@ title: Release notes for 0.8
 
     Added reload function.
 
-    Copy to clipboard
-
          task "reload-apache", sub {
              service apache2 => "reload";
          };
@@ -48,8 +42,6 @@ title: Release notes for 0.8
 -   **Database Functions**
 
     Extended the Database module to support inserts, deletes and updates.
-
-    Copy to clipboard
 
          task "db", sub {
            my @data = db select => {

--- a/content/docs/release_notes/0.8.md
+++ b/content/docs/release_notes/0.8.md
@@ -8,66 +8,70 @@ title: Release notes for 0.8
 
     Added chown, chgrp and chmod functions to work transparently over ssh.
 
-         task "change", sub {
-             chown "jan", "/home/jan", 
-                               recursive => 1;
-           
-             chgrp "user", "/home/jan", 
-                               recursive => 1;
+        task "change", sub {
+          chown "jan", "/home/jan", recursive => 1;
 
-            chmod 644, "/etc/passwd";
+          chgrp "user", "/home/jan", recursive => 1;
 
-         };
+          chmod 644, "/etc/passwd";
+
+        };
 
 -   **File Manipulation Functions**
 
     Added two functions to manipulate files: delete\_lines\_matching and append\_if\_no\_such\_line.
 
-         task "manip", sub {
-            delete_lines_matching "/var/log/auth.log", matching => "root";
-            delete_lines_matching "/var/log/auth.log", matching => qr{Failed};
-            
-            append_if_no_such_line "/etc/groups", "mygroup:*:100:myuser1,myuser2", "mygroup";
-            append_if_no_such_line "/etc/groups", "mygroup:*:100:myuser1,myuser2", qr{^mygroup};
-         };
+        task "manip", sub {
+          delete_lines_matching "/var/log/auth.log", matching => "root";
+          delete_lines_matching "/var/log/auth.log", matching => qr{Failed};
+
+          append_if_no_such_line "/etc/groups",
+            "mygroup:*:100:myuser1,myuser2", "mygroup";
+          append_if_no_such_line "/etc/groups",
+            "mygroup:*:100:myuser1,myuser2", qr{^mygroup};
+        };
 
 -   **Services**
 
     Added reload function.
 
-         task "reload-apache", sub {
-             service apache2 => "reload";
-         };
+        task "reload-apache", sub {
+          service apache2 => "reload";
+        };
 
 -   **Database Functions**
 
     Extended the Database module to support inserts, deletes and updates.
 
-         task "db", sub {
-           my @data = db select => {
-                          fields => "*",
-                          from   => "table",
-                          where  => "enabled=1",
-                       };
-                   
-           db insert => "table", {
-                        field1 => "value1",
-                         field2 => "value2",
-                         field3 => 5,
-                       };
-                        
-           db update => "table", {
-                            set => {
-                               field1 => "newvalue",
-                               field2 => "newvalue2",
-                            },
-                            where => "id=5",
-                        };
-                        
-           db delete => "table", {
-                         where => "id < 5",
-                      };
-         };
+        task "db", sub {
+          my @data = db select => {
+            fields => "*",
+            from   => "table",
+            where  => "enabled=1",
+          };
+
+          db
+            insert => "table",
+            {
+            field1 => "value1",
+            field2 => "value2",
+            field3 => 5,
+            };
+
+          db
+            update => "table",
+            {
+            set => {
+              field1 => "newvalue",
+              field2 => "newvalue2",
+            },
+            where => "id=5",
+            };
+
+          db
+            delete => "table",
+            { where => "id < 5", };
+        };
 
 -   **Distribution Support**
 

--- a/content/docs/release_notes/0.9.md
+++ b/content/docs/release_notes/0.9.md
@@ -14,42 +14,43 @@ title: Release notes for 0.9
 
     Added Transaction and the possibility to rollback on transaction failures.
 
-         use Rex::Transaction;
-         task "do_something", sub {
-            on_rollback {
-                unlink "/tmp/test";
-            };
-            
-            touch "/tmp/test";
-            die;
-         };
-         
-         task "make", sub {
-            transaction {
-               do_task "do_something";
-            };
-         };
+        use Rex::Transaction;
+        task "do_something", sub {
+          on_rollback {
+            unlink "/tmp/test";
+          };
+
+          touch "/tmp/test";
+          die;
+        };
+
+        task "make", sub {
+          transaction {
+            do_task "do_something";
+          };
+        };
 
 -   **Inventory**
 
     Now it's possible to make an inventory of your hardware.
 
-         use Data::Dumper;
-         use Rex::Commands::Inventory;
-         task "inventory", "server1", "server2", sub {
-            my $inventory = inventor();
-            print Dumper($inventory);
-         };
+        use Data::Dumper;
+        use Rex::Commands::Inventory;
+        task "inventory", "server1", "server2", sub {
+          my $inventory = inventor();
+          print Dumper($inventory);
+        };
 
 -   New function **file**
 
     Use this function to upload a file to your servers.
 
-         task "upload", "server1", sub {
-            file "$path/vhost.conf",
-               content   => template("../../templates/vhost.conf.tpl"),
-               # on change of the file, do something
-               on_change => sub { say "file was modified"; };
-         };
+        task "upload", "server1", sub {
+          file "$path/vhost.conf",
+            content => template("../../templates/vhost.conf.tpl"),
+
+            # on change of the file, do something
+            on_change => sub { say "file was modified"; };
+        };
 
 

--- a/content/docs/release_notes/0.9.md
+++ b/content/docs/release_notes/0.9.md
@@ -14,8 +14,6 @@ title: Release notes for 0.9
 
     Added Transaction and the possibility to rollback on transaction failures.
 
-    Copy to clipboard
-
          use Rex::Transaction;
          task "do_something", sub {
             on_rollback {
@@ -36,8 +34,6 @@ title: Release notes for 0.9
 
     Now it's possible to make an inventory of your hardware.
 
-    Copy to clipboard
-
          use Data::Dumper;
          use Rex::Commands::Inventory;
          task "inventory", "server1", "server2", sub {
@@ -48,8 +44,6 @@ title: Release notes for 0.9
 -   New function **file**
 
     Use this function to upload a file to your servers.
-
-    Copy to clipboard
 
          task "upload", "server1", sub {
             file "$path/vhost.conf",

--- a/content/docs/release_notes/1.0.0.md
+++ b/content/docs/release_notes/1.0.0.md
@@ -34,16 +34,17 @@ To use this it is required to have *augtool* installed on your servers. This is 
     use Rex::Commands::Augeas;
 
     task "prepare", sub {
-      augeas insert => "/files/etc/hosts",
+      augeas
+        insert    => "/files/etc/hosts",
         label     => "01",
         after     => "/7",
         ipaddr    => "192.168.2.23",
         canonical => "frontend01";
 
-      augeas modify => 
+      augeas modify =>
         "/files/etc/ssh/sshd_config/PermitRootLogin" => "without-password",
-        on_change => sub {
-          service sshd => "restart";
+        on_change                                    => sub {
+        service sshd => "restart";
         };
     };
 
@@ -58,10 +59,21 @@ The PkgConf commands are especially usefull on debian/ubuntu systems to query an
     use Rex::Commands::PkgConf;
 
     task "prepare", sub {
-      set_pkgconf("mysql-server-5.5", [
-        { question => 'mysql-server/root_password',       type => 'string', value => 'mysecret' },
-        { question => 'mysql-server/root_password_again', type => 'string', value => 'mysecret' },
-      ]);
+      set_pkgconf(
+        "mysql-server-5.5",
+        [
+          {
+            question => 'mysql-server/root_password',
+            type     => 'string',
+            value    => 'mysecret'
+          },
+          {
+            question => 'mysql-server/root_password_again',
+            type     => 'string',
+            value    => 'mysecret'
+          },
+        ]
+      );
     };
 
 #### tty usage
@@ -72,7 +84,7 @@ If you're using `use Rex -feature => ['1.0'];` tty usage is disabled. This incre
 
 If you can't change this behaviour you can always use the *tty* feature to tell Rex to spawn a tty.
 
-    use Rex -feature => ['1.0', 'tty'];
+    use Rex -feature => [ '1.0', 'tty' ];
 
 #### base
 

--- a/content/docs/release_notes/1.2.0.md
+++ b/content/docs/release_notes/1.2.0.md
@@ -17,8 +17,8 @@ Now it is possible to merge CMDB data from different levels of the CMDB hierarch
 <!-- -->
 
     set cmdb {
-      type => 'YAML',
-      path => 'cmdb',
+      type           => 'YAML',
+      path           => 'cmdb',
       merge_behavior => 'LEFT_PRECEDENT',
     };
 
@@ -27,13 +27,13 @@ Now it is possible to merge CMDB data from different levels of the CMDB hierarch
 <!-- -->
 
     set cmdb {
-      type => 'YAML',
-      path => 'cmdb',
+      type           => 'YAML',
+      path           => 'cmdb',
       merge_behavior => {
-        SCALAR => { ... },
-        ARRAY  => { ... },
-        HASH   => { ... }
-      }, 
+        SCALAR => {...},
+        ARRAY  => {...},
+        HASH   => {...}
+      },
     };
 
 -   Add YAML CMDB merging support (fix \#499) - Ferenc Erki


### PR DESCRIPTION
While working on the syntax highlighting, I noticed that the release notes documents could use some cleanup, so I decided to go for it before moving on to further conversions.

The cleanup has two parts:

1. Remove `Copy to clipboard` leftover strings
2. Run perltidy on the code examples