### PR TITLE
Clean up code examples

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -3,3 +3,4 @@
 --minimum-space-to-comment=1
 --no-outdent-long-quotes
 --no-outdent-long-comments
+--character-encoding=utf8

--- a/content/care/help__r__ex.md
+++ b/content/care/help__r__ex.md
@@ -24,7 +24,7 @@ If you have any questions about how to implement something, join us on irc.freen
 ## Sponsoring
 
 As mentioned above (R)?ex is completely developed by volunteers. Which means there is no guarantee that a specific feature will be released at a defined date. If you need a special feature you can sponsor it, so we can focus our efforts on that feature. In this case contact us at feature@rexify.org.
-Those sponsored features will also be released under the same license as (R)?ex itself. So it is guaranteed that it will remain  compatible with following releases and you will also have the benefit of a community finding potential bugs or contributing enhancements.
+Those sponsored features will also be released under the same license as (R)?ex itself. So it is guaranteed that it will remain  compatible with following releases and you will also have the benefit of a community finding potential bugs or contributing enhancements.
 
 ## Hardware
 
@@ -34,4 +34,4 @@ One special case is hardware. There can't be enough hardware/environments where 
 
 We want to give a special thanks to the listed companies.
 
-[<img src="/public/images/skin/rexify.org/adjust_transparent.png" width="278" height="86" />](https://www.adjust.com/) 
+[<img src="/public/images/skin/rexify.org/adjust_transparent.png" width="278" height="86" />](https://www.adjust.com/) 

--- a/content/docs/faq/index.md
+++ b/content/docs/faq/index.md
@@ -34,9 +34,9 @@ If you want to print the output to your terminal you have to call it in a scalar
 
     ```perl
     task 'mytask', sub {
-      my $parameters = shift;
-      my $parameter1_value = $parameters->{parameter1};
-      my $parameter2_value = $parameters->{parameter2};
+      my $parameters = shift;
+      my $parameter1_value = $parameters->{parameter1};
+      my $parameter2_value = $parameters->{parameter2};
     };
     ```
 
@@ -56,8 +56,8 @@ Then, you can run your shell code remotely as:
     use Rex::Misc::ShellBlock;
 
     task "myexec", sub {
-      shell_block <<EOF;
-        echo "hi"
+      shell_block <<EOF;
+        echo "hi"
     EOF
     };
     ```
@@ -71,7 +71,7 @@ If you have a local script 'files/script', you can run it on the remote using th
     ```perl
     use Rex::Misc::ShellBlock;
     task "myexec", sub {
-      shell_block template('files/script');
+      shell_block template('files/script');
     };
     ```
 
@@ -86,7 +86,7 @@ Given the same scenario as above, but with the additional requirement to run the
         command => sub {
           shell_block template('files/script');
         },
-        user    => 'root'
+        user    => 'root'
       };
     };
     ```
@@ -98,7 +98,7 @@ Rex assigns the exit code from the remote invocation of `run` or `shell_block` s
 ## How do I use Rex's built-in logger for ERROR/WARN/INFO/DEBUG messages?
 
     ```perl
-    Rex::Logger::info("some message");           # for INFO  (green)
-    Rex::Logger::info("some message", "warn");   # for WARN  (yellow)
-    Rex::Logger::info("some message", "error");  # for ERROR (red)
+    Rex::Logger::info("some message");           # for INFO  (green)
+    Rex::Logger::info("some message", "warn");   # for WARN  (yellow)
+    Rex::Logger::info("some message", "error");  # for ERROR (red)
     ```

--- a/content/docs/faq/index.md
+++ b/content/docs/faq/index.md
@@ -34,7 +34,7 @@ If you want to print the output to your terminal you have to call it in a scalar
 
     ```perl
     task 'mytask', sub {
-      my $parameters = shift;
+      my $parameters       = shift;
       my $parameter1_value = $parameters->{parameter1};
       my $parameter2_value = $parameters->{parameter2};
     };
@@ -54,7 +54,7 @@ Then, you can run your shell code remotely as:
 
     ```perl
     use Rex::Misc::ShellBlock;
-
+    
     task "myexec", sub {
       shell_block <<EOF;
         echo "hi"
@@ -86,7 +86,7 @@ Given the same scenario as above, but with the additional requirement to run the
         command => sub {
           shell_block template('files/script');
         },
-        user    => 'root'
+        user => 'root'
       };
     };
     ```
@@ -98,7 +98,7 @@ Rex assigns the exit code from the remote invocation of `run` or `shell_block` s
 ## How do I use Rex's built-in logger for ERROR/WARN/INFO/DEBUG messages?
 
     ```perl
-    Rex::Logger::info("some message");           # for INFO  (green)
-    Rex::Logger::info("some message", "warn");   # for WARN  (yellow)
-    Rex::Logger::info("some message", "error");  # for ERROR (red)
+    Rex::Logger::info("some message"); # for INFO  (green)
+    Rex::Logger::info( "some message", "warn" );  # for WARN  (yellow)
+    Rex::Logger::info( "some message", "error" ); # for ERROR (red)
     ```

--- a/content/docs/guides/cheat_sheet/index.md
+++ b/content/docs/guides/cheat_sheet/index.md
@@ -23,8 +23,7 @@ Run a remote command and returns its output.
 #### Example to just run a command if a file doesn't exists
 
     ```perl
-    run "/tmp/install_service.sh",
-      creates => "/opt/myservice/conf.xml";
+    run "/tmp/install_service.sh", creates => "/opt/myservice/conf.xml";
     ```
 
 #### Example to run a command and get its output
@@ -54,13 +53,13 @@ Manage files on remote systems.
 
         ```perl
         file "/etc/ntpd.conf",
-          ensure => "present",
-          source => "files/ntpd.conf",
-          owner  => "root",
-          group  => "root",
-          mode   => 644,
+          ensure    => "present",
+          source    => "files/ntpd.conf",
+          owner     => "root",
+          group     => "root",
+          mode      => 644,
           on_change => sub {
-            service ntpd => "restart";
+          service ntpd => "restart";
           };
         ```
 
@@ -75,9 +74,9 @@ Install a package on the remote system.
 
         ```perl
         pkg "ntpd",
-          ensure => "latest",
+          ensure    => "latest",
           on_change => sub {
-            service ntpd => "restart";
+          service ntpd => "restart";
           };
         ```
 
@@ -99,8 +98,7 @@ This function can be called as a resource or as a normal function to directly st
 #### Example for calling as resource
 
     ```perl
-    service "nptd",
-      ensure => "started";
+    service "nptd", ensure => "started";
     ```
 
 #### Example for calling as function
@@ -158,15 +156,15 @@ Manage user accounts.
 
         ```perl
         account "krimdomu",
-           ensure         => "present",  # default
-           uid            => 509,
-           home           => '/home/krimdomu',
-           comment        => 'User Account',
-           expire         => '2011-05-30',
-           groups         => [ 'users', 'wheel' ],
-           password       => 'blahblah',
-           create_home    => TRUE,
-           ssh_key        => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChUw...";
+          ensure      => "present",                                      # default
+          uid         => 509,
+          home        => '/home/krimdomu',
+          comment     => 'User Account',
+          expire      => '2011-05-30',
+          groups      => [ 'users', 'wheel' ],
+          password    => 'blahblah',
+          create_home => TRUE,
+          ssh_key     => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChUw...";
         ```
 
 ### group($group\_name, %options)
@@ -180,6 +178,5 @@ Manage groups.
 - system - Create a system group.
 
         ```perl
-        group "users",
-          ensure => "present";
+        group "users", ensure => "present";
         ```

--- a/content/docs/guides/cloud_management/manage_your_amazon_ec2_instances.md
+++ b/content/docs/guides/cloud_management/manage_your_amazon_ec2_instances.md
@@ -41,11 +41,11 @@ Insert the following code in your new Rexfile.
     cloud_region "ec2.eu-west-1.amazonaws.com";
 
     task "create", sub {
-       cloud_instance create => { 
-                image_id => "ami-02103876",
-                name     => "static01",
-                key      => "dev-test",
-             };
+       cloud_instance create => { 
+                image_id => "ami-02103876",
+                name     => "static01",
+                key      => "dev-test",
+             };
     };
     ```
 
@@ -57,14 +57,14 @@ Sometimes you need an instance with a persistent storage volume. To achieve this
 
     ```perl
     task "create", sub {
-       my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a", };
-       cloud_instance create => { 
-                image_id => "ami-02103876",
-                name     => "static01",
-                key      => "dev-test",
-                volume   => $vol_id,
-                zone     => "eu-west-1a",
-             };
+       my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a", };
+       cloud_instance create => { 
+                image_id => "ami-02103876",
+                name     => "static01",
+                key      => "dev-test",
+                volume   => $vol_id,
+                zone     => "eu-west-1a",
+             };
     };
     ```
 
@@ -74,8 +74,8 @@ To get a list of all regions and zone you can use the following functions.
 
     ```perl
     task "list", sub {
-       print Dumper get_cloud_regions;
-       print Dumper get_cloud_availability_zones;
+       print Dumper get_cloud_regions;
+       print Dumper get_cloud_availability_zones;
     };
     ```
 
@@ -85,8 +85,8 @@ To get a list of all your instances and volumes you can use these functions.
 
     ```perl
     task "list", sub {
-       print Dumper cloud_instance_list;
-       print Dumper cloud_volume_list;
+       print Dumper cloud_instance_list;
+       print Dumper cloud_volume_list;
     };
     ```
 
@@ -96,8 +96,8 @@ If you don't need your instances or volumes anymore, you can just destroy them.
 
     ```perl
     task "destroy", sub {
-       cloud_volume delete => "$volume_id";
-       cloud_instance terminate => "$instance_id";
+       cloud_volume delete => "$volume_id";
+       cloud_instance terminate => "$instance_id";
     };
     ```
 
@@ -115,21 +115,21 @@ Now we need to add some software to our fresh EC2 instance.
 
     ```perl
     task "prepare", group => "ec2", sub {
-       run "apt-get update";
-       install package => "apache2";
+       run "apt-get update";
+       install package => "apache2";
 
-       service apache2 => "ensure", "started";
+       service apache2 => "ensure", "started";
 
-       # deploy your webapp, see Rex::Apache::Deploy for more information.
-       deploy "my-site.tar.gz";
+       # deploy your webapp, see Rex::Apache::Deploy for more information.
+       deploy "my-site.tar.gz";
 
-       # or upload some files
-       file "/etc/passwd",
-          source => "/etc/passwd";
+       # or upload some files
+       file "/etc/passwd",
+          source => "/etc/passwd";
 
-       # do what ever you want
-       use Rex::Commands::Iptables;
-       close_port "all";
+       # do what ever you want
+       use Rex::Commands::Iptables;
+       close_port "all";
     };
     ```
 

--- a/content/docs/guides/cloud_management/manage_your_amazon_ec2_instances.md
+++ b/content/docs/guides/cloud_management/manage_your_amazon_ec2_instances.md
@@ -28,24 +28,24 @@ Insert the following code in your new Rexfile.
     ```perl
     use Rex -feature => ['1.0'];
     use Rex::Commands::Cloud;
-
+    
     user "root";
     public_key "/path/to/your/just/created/amazon-public.key";
     private_key "/path/to/your/just/downloaded/amazon-private-key.pem";
-
-    my $access_key = "your-access-key";
+    
+    my $access_key        = "your-access-key";
     my $secret_access_key = "your-secret-key";
-
+    
     cloud_service "Amazon";
     cloud_auth "$access_key", "$secret_access_key";
     cloud_region "ec2.eu-west-1.amazonaws.com";
-
+    
     task "create", sub {
-       cloud_instance create => { 
-                image_id => "ami-02103876",
-                name     => "static01",
-                key      => "dev-test",
-             };
+      cloud_instance create => {
+        image_id => "ami-02103876",
+        name     => "static01",
+        key      => "dev-test",
+      };
     };
     ```
 
@@ -57,14 +57,14 @@ Sometimes you need an instance with a persistent storage volume. To achieve this
 
     ```perl
     task "create", sub {
-       my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a", };
-       cloud_instance create => { 
-                image_id => "ami-02103876",
-                name     => "static01",
-                key      => "dev-test",
-                volume   => $vol_id,
-                zone     => "eu-west-1a",
-             };
+      my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a", };
+      cloud_instance create => {
+        image_id => "ami-02103876",
+        name     => "static01",
+        key      => "dev-test",
+        volume   => $vol_id,
+        zone     => "eu-west-1a",
+      };
     };
     ```
 
@@ -74,8 +74,8 @@ To get a list of all regions and zone you can use the following functions.
 
     ```perl
     task "list", sub {
-       print Dumper get_cloud_regions;
-       print Dumper get_cloud_availability_zones;
+      print Dumper get_cloud_regions;
+      print Dumper get_cloud_availability_zones;
     };
     ```
 
@@ -85,8 +85,8 @@ To get a list of all your instances and volumes you can use these functions.
 
     ```perl
     task "list", sub {
-       print Dumper cloud_instance_list;
-       print Dumper cloud_volume_list;
+      print Dumper cloud_instance_list;
+      print Dumper cloud_volume_list;
     };
     ```
 
@@ -96,8 +96,8 @@ If you don't need your instances or volumes anymore, you can just destroy them.
 
     ```perl
     task "destroy", sub {
-       cloud_volume delete => "$volume_id";
-       cloud_instance terminate => "$instance_id";
+      cloud_volume delete      => "$volume_id";
+      cloud_instance terminate => "$instance_id";
     };
     ```
 
@@ -114,23 +114,24 @@ If you have many instances you can easily add them all into a hostgroup.
 Now we need to add some software to our fresh EC2 instance.
 
     ```perl
-    task "prepare", group => "ec2", sub {
-       run "apt-get update";
-       install package => "apache2";
-
-       service apache2 => "ensure", "started";
-
-       # deploy your webapp, see Rex::Apache::Deploy for more information.
-       deploy "my-site.tar.gz";
-
-       # or upload some files
-       file "/etc/passwd",
-          source => "/etc/passwd";
-
-       # do what ever you want
-       use Rex::Commands::Iptables;
-       close_port "all";
-    };
+    task "prepare",
+      group => "ec2",
+      sub {
+      run "apt-get update";
+      install package => "apache2";
+    
+      service apache2 => "ensure", "started";
+    
+      # deploy your webapp, see Rex::Apache::Deploy for more information.
+      deploy "my-site.tar.gz";
+    
+      # or upload some files
+      file "/etc/passwd", source => "/etc/passwd";
+    
+      # do what ever you want
+      use Rex::Commands::Iptables;
+      close_port "all";
+      };
     ```
 
 Now you can run Rex to create the instance and prepare the system for use.

--- a/content/docs/guides/feature_flags.md
+++ b/content/docs/guides/feature_flags.md
@@ -41,7 +41,7 @@ This is the current list of feature flags:
 | source\_global\_profile                | 0.44      | Source /etc/profile before running a command. |
 | exec\_autodie                          | 0.44      | If you execute a command with run() Rex will die() if the command returns a RETVAL != 0. |
 | exec\_and\_sleep                       | 0.43      | Sometimes some commands that fork away didn't keep running. With this flag rex will wait a few ms before exiting the shell. |
-| disable\_strict\_host\_key\_checking   | 0.43      | Disabling strict host key checking for openssh connection mode. |
+| disable\_strict\_host\_key\_checking   | 0.43      | Disabling strict host key checking for openssh connection mode. |
 | reporting                              | 0.43      | Enable reporting |
 | empty\_groups                          | 0.42      | Enable usage of empty groups. |
 | use\_server\_auth                      | 0.42      | Enable the usage of special authentication options for servers. |

--- a/content/docs/guides/just_enough_perl_for_rex.md
+++ b/content/docs/guides/just_enough_perl_for_rex.md
@@ -13,10 +13,10 @@ If you have suggestions or wishes, please post a comment, tell us in our \#rex c
 Scalars can contain single items, like strings, numbers, objects or references.
 
     ```perl
-    my $name = "John";      # this is a string
-    my $age = 28;           # this is a number (integer)
-    my $float = 28.5;       # also a number, but a float
-    my $car = Car->new();   # this is an object from the class Car
+    my $name = "John";      # this is a string
+    my $age = 28;           # this is a number (integer)
+    my $float = 28.5;       # also a number, but a float
+    my $car = Car->new();   # this is an object from the class Car
     ```
 
 ### Array variables
@@ -47,7 +47,7 @@ Join the items of an array into a string:
 
     ```perl
     my @names = ( "John", "Fred", "Carl", "Lewis" );
-    my $string = join( ",", @names );     # -> John,Fred,Carl,Lewis
+    my $string = join( ",", @names );     # -> John,Fred,Carl,Lewis
     ```
 
 If you want to iterate over an array, do it like this:
@@ -65,8 +65,8 @@ Hashes are like arrays, but with named indexes, called keys.
     ```perl
     my %person = (
       name => "John",
-      age  => 28,
-      city => "New York"
+      age  => 28,
+      city => "New York"
     );
     ```
 
@@ -82,7 +82,7 @@ If you want to iterate over a hash, do it like this:
 
     ```perl
     for my $key ( keys %person ) {
-      say "key: $key -> value: " . $person{$key};
+      say "key: $key -> value: " . $person{$key};
     }
     ```
 
@@ -92,23 +92,23 @@ But remember an important note: hashes are always unsorted.
 
     ```perl
     if ( $name eq "John" ) {
-      say "Hello, my name is John!";
+      say "Hello, my name is John!";
     } else {
-      say "Well, my name is not John...";
+      say "Well, my name is not John...";
     }
 
     if ( $name ne "John" ) {
-      say "Yes, my name is NOT John...";
+      say "Yes, my name is NOT John...";
     } else {
-      say "Hello, my name is John!";
+      say "Hello, my name is John!";
     }
 
     if ( $age < 30 ) {
-      say "I'm younger than 30.";
+      say "I'm younger than 30.";
     } elsif ( $age >= 30 && $age <= 50 ) {
-      say "Well, I'm between 30 and 50.";
+      say "Well, I'm between 30 and 50.";
     } else {
-      say "I'm older than 50.";
+      say "I'm older than 50.";
     } 
     ```
 
@@ -116,12 +116,12 @@ But remember an important note: hashes are always unsorted.
 
     ```perl
     for my $num (1..5) {
-      say "> $num";
+      say "> $num";
     }
 
     # looping over an array
     for my $item (@array) {
-      say "> $item";
+      say "> $item";
     } 
     ```
 
@@ -129,37 +129,37 @@ But remember an important note: hashes are always unsorted.
 
     ```perl
     my $name = "John";
-    if ( $name =~ m/john/ ) {     # will not match, because the "J" in $name is uppercase
+    if ( $name =~ m/john/ ) {     # will not match, because the "J" in $name is uppercase
     }
 
-    if ( $name =~ m/john/i ) {    # _will_ match, because we use the "i" modifier for case-insensitive matching
+    if ( $name =~ m/john/i ) {    # _will_ match, because we use the "i" modifier for case-insensitive matching
     }
 
-    $name =~ s/john/Fred/i;       # this will replace the first match of "john" (regardless of its case) with "Fred"
-    $name =~ s/john/Fred/ig;      # this will replace all matches of "john" (regardless of its case) with "Fred"
+    $name =~ s/john/Fred/i;       # this will replace the first match of "john" (regardless of its case) with "Fred"
+    $name =~ s/john/Fred/ig;      # this will replace all matches of "john" (regardless of its case) with "Fred"
     ```
 
 ## Functions
 
     ```perl
-    sub my_function {      # define the function called "my_function"
+    sub my_function {      # define the function called "my_function"
     }
 
-    sub my_function2 {      # define the function called "my_function2" 
-      my $param1 = $_[0]; # get the 1st parameter and save it in $param1
-      my $param2 = $_[1]; # get the 2nd parameter and save it in $param2
-      my $param3 = $_[2]; # get the 3rd parameter and save it in $param3
+    sub my_function2 {      # define the function called "my_function2" 
+      my $param1 = $_[0]; # get the 1st parameter and save it in $param1
+      my $param2 = $_[1]; # get the 2nd parameter and save it in $param2
+      my $param3 = $_[2]; # get the 3rd parameter and save it in $param3
     }
 
     sub my_function3 {
-      my ($param1, $param2, $param3) = @_; # the same as above in "my_function2"
+      my ($param1, $param2, $param3) = @_; # the same as above in "my_function2"
     }
 
-    my_function();     # call the function "my_function"
-    my_function;       # also calls "my_function"
-    &my_function;      # also calls "my_function"
-    my_function("john", 28);    # call "my_function" with 2 parameters
-    my_function "john", 28;     # also calls "my_function" with 2 parameters: the brackets are not needed
+    my_function();     # call the function "my_function"
+    my_function;       # also calls "my_function"
+    &my_function;      # also calls "my_function"
+    my_function("john", 28);    # call "my_function" with 2 parameters
+    my_function "john", 28;     # also calls "my_function" with 2 parameters: the brackets are not needed
     ```
 
 ## Useful helpers
@@ -173,10 +173,10 @@ Dump the content of a scalar, array or hash
     say Dumper(%hash);
     ```
 
- 
+ 
 
 ## More Documentation
 
 If you want to learn more Perl you can find a great online tutorial on [Perl Maven](http://perlmaven.com/perl-tutorial).
 
- 
+ 

--- a/content/docs/guides/just_enough_perl_for_rex.md
+++ b/content/docs/guides/just_enough_perl_for_rex.md
@@ -145,14 +145,14 @@ But remember an important note: hashes are always unsorted.
     sub my_function {      # define the function called "my_function"
     }
 
-    sub my_function {      # define the function called "my_function" 
+    sub my_function2 {      # define the function called "my_function2" 
       my $param1 = $_[0]; # get the 1st parameter and save it in $param1
       my $param2 = $_[1]; # get the 2nd parameter and save it in $param2
       my $param3 = $_[2]; # get the 3rd parameter and save it in $param3
     }
 
-    sub my_function {
-      my ($param1, $param2, $param3) = @_; # the same as above
+    sub my_function3 {
+      my ($param1, $param2, $param3) = @_; # the same as above in "my_function2"
     }
 
     my_function();     # call the function "my_function"

--- a/content/docs/guides/just_enough_perl_for_rex.md
+++ b/content/docs/guides/just_enough_perl_for_rex.md
@@ -13,10 +13,10 @@ If you have suggestions or wishes, please post a comment, tell us in our \#rex c
 Scalars can contain single items, like strings, numbers, objects or references.
 
     ```perl
-    my $name = "John";      # this is a string
-    my $age = 28;           # this is a number (integer)
+    my $name  = "John";     # this is a string
+    my $age   = 28;         # this is a number (integer)
     my $float = 28.5;       # also a number, but a float
-    my $car = Car->new();   # this is an object from the class Car
+    my $car   = Car->new(); # this is an object from the class Car
     ```
 
 ### Array variables
@@ -24,7 +24,7 @@ Scalars can contain single items, like strings, numbers, objects or references.
 Arrays are lists of scalars. Like a grocery list.
 
     ```perl
-    my @names = ( "John", "Fred", "Charley" );
+    my @names  = ( "John", "Fred", "Charley" );
     my @to_buy = qw( Cheese Butter Salt Lemons Oranges Apples );
     ```
 
@@ -40,14 +40,14 @@ Split a string into an array:
 
     ```perl
     my $string = "John,Fred,Carl,Lewis";
-    my @names = split( /,/, $string );
+    my @names  = split( /,/, $string );
     ```
 
 Join the items of an array into a string:
 
     ```perl
-    my @names = ( "John", "Fred", "Carl", "Lewis" );
-    my $string = join( ",", @names );     # -> John,Fred,Carl,Lewis
+    my @names  = ( "John", "Fred", "Carl", "Lewis" );
+    my $string = join( ",", @names );                # -> John,Fred,Carl,Lewis
     ```
 
 If you want to iterate over an array, do it like this:
@@ -93,73 +93,77 @@ But remember an important note: hashes are always unsorted.
     ```perl
     if ( $name eq "John" ) {
       say "Hello, my name is John!";
-    } else {
+    }
+    else {
       say "Well, my name is not John...";
     }
-
+    
     if ( $name ne "John" ) {
       say "Yes, my name is NOT John...";
-    } else {
+    }
+    else {
       say "Hello, my name is John!";
     }
-
+    
     if ( $age < 30 ) {
       say "I'm younger than 30.";
-    } elsif ( $age >= 30 && $age <= 50 ) {
+    }
+    elsif ( $age >= 30 && $age <= 50 ) {
       say "Well, I'm between 30 and 50.";
-    } else {
+    }
+    else {
       say "I'm older than 50.";
-    } 
+    }
     ```
 
 ## Loops
 
     ```perl
-    for my $num (1..5) {
+    for my $num ( 1 .. 5 ) {
       say "> $num";
     }
-
+    
     # looping over an array
     for my $item (@array) {
       say "> $item";
-    } 
+    }
     ```
 
 ## Regular expressions
 
     ```perl
     my $name = "John";
-    if ( $name =~ m/john/ ) {     # will not match, because the "J" in $name is uppercase
+    if ( $name =~ m/john/ ) { # will not match, because the "J" in $name is uppercase
     }
-
-    if ( $name =~ m/john/i ) {    # _will_ match, because we use the "i" modifier for case-insensitive matching
+    
+    if ( $name =~ m/john/i ) { # _will_ match, because we use the "i" modifier for case-insensitive matching
     }
-
-    $name =~ s/john/Fred/i;       # this will replace the first match of "john" (regardless of its case) with "Fred"
-    $name =~ s/john/Fred/ig;      # this will replace all matches of "john" (regardless of its case) with "Fred"
+    
+    $name =~ s/john/Fred/i; # this will replace the first match of "john" (regardless of its case) with "Fred"
+    $name =~ s/john/Fred/ig; # this will replace all matches of "john" (regardless of its case) with "Fred"
     ```
 
 ## Functions
 
     ```perl
-    sub my_function {      # define the function called "my_function"
+    sub my_function { # define the function called "my_function"
     }
-
-    sub my_function2 {      # define the function called "my_function2" 
+    
+    sub my_function2 { # define the function called "my_function2"
       my $param1 = $_[0]; # get the 1st parameter and save it in $param1
       my $param2 = $_[1]; # get the 2nd parameter and save it in $param2
       my $param3 = $_[2]; # get the 3rd parameter and save it in $param3
     }
-
+    
     sub my_function3 {
-      my ($param1, $param2, $param3) = @_; # the same as above in "my_function2"
+      my ( $param1, $param2, $param3 ) = @_; # the same as above in "my_function2"
     }
-
-    my_function();     # call the function "my_function"
-    my_function;       # also calls "my_function"
-    &my_function;      # also calls "my_function"
-    my_function("john", 28);    # call "my_function" with 2 parameters
-    my_function "john", 28;     # also calls "my_function" with 2 parameters: the brackets are not needed
+    
+    my_function();                           # call the function "my_function"
+    my_function;                             # also calls "my_function"
+    &my_function;                            # also calls "my_function"
+    my_function( "john", 28 );               # call "my_function" with 2 parameters
+    my_function "john", 28; # also calls "my_function" with 2 parameters: the brackets are not needed
     ```
 
 ## Useful helpers

--- a/content/docs/guides/manage_openwrt.md
+++ b/content/docs/guides/manage_openwrt.md
@@ -49,12 +49,12 @@ A massively subjective comparison of these two may help to make your decision:
 
 ##### openssh-sftp-server
 
--       easier to set up
--       a bit smaller size in itself
--       depends on libopenssl and zlib (and they are "huge" and probably not needed by other packages)
--       only supports SFTP v3 (that should be fine in general though)
--       widespread use
--       BSD licensed
+-       easier to set up
+-       a bit smaller size in itself
+-       depends on libopenssl and zlib (and they are "huge" and probably not needed by other packages)
+-       only supports SFTP v3 (that should be fine in general though)
+-       widespread use
+-       BSD licensed
 
 It can be set up with the following commands:
 

--- a/content/docs/guides/start_using__r__ex.md
+++ b/content/docs/guides/start_using__r__ex.md
@@ -65,10 +65,12 @@ Now change into this directory and create a file called Rexfile with the followi
     group myservers => "mywebserver", "mymailserver", "myfileserver";
     
     desc "Get the uptime of all servers";
-    task "uptime", group => "myservers", sub {
-       my $output = run "uptime";
-       say $output;
-    };
+    task "uptime",
+      group => "myservers",
+      sub {
+      my $output = run "uptime";
+      say $output;
+      };
     ```
 
 This Example will login as my-user with the password my-password on all the servers in the group myservers and run the command "uptime".
@@ -86,9 +88,11 @@ To add a second task, just add the next lines to your Rexfile.
 
     ```perl
     desc "Start Apache Service";
-    task "start_apache", group => "myservers", sub {
-        service "apache2" => "start";
-    };
+    task "start_apache",
+      group => "myservers",
+      sub {
+      service "apache2" => "start";
+      };
     ```
 
 This task will start the service apache2 on all the servers in the myservers group.
@@ -137,31 +141,32 @@ In this example you will learn how to install and configure ntp. You can adapt t
     ```perl
     # Rexfile
     use Rex -feature => ['1.3'];
-
+    
     user "root";
     private_key "/root/.ssh/id_rsa";
     public_key "/root/.ssh/id_rsa.pub";
-
+    
     group all_servers => "srv[001..150]";
-
-    task "setup_ntp", group => "all_servers", sub {
-       # first we will install the package
-       pkg "ntpd",
-         ensure => "present";
-
-       # then we will upload a configuration file.
-       # the configuration file is located in a subdirectory files/etc.
-       file "/etc/ntp.conf",
-          source    => "files/etc/ntp.conf",
-          on_change => sub {
-             # we define a on_change hook, so that the ntpd server gets restarted if the file is modified.
-             service ntpd => "restart";
-          };
-
-       # now we register the service to start at boot time.
-       service "ntpd",
-         ensure => "started";
-    };
+    
+    task "setup_ntp",
+      group => "all_servers",
+      sub {
+      # first we will install the package
+      pkg "ntpd", ensure => "present";
+    
+      # then we will upload a configuration file.
+      # the configuration file is located in a subdirectory files/etc.
+      file "/etc/ntp.conf",
+        source    => "files/etc/ntp.conf",
+        on_change => sub {
+    
+        # we define a on_change hook, so that the ntpd server gets restarted if the file is modified.
+        service ntpd => "restart";
+        };
+    
+      # now we register the service to start at boot time.
+      service "ntpd", ensure => "started";
+      };
     ```
 
 That's all.

--- a/content/docs/guides/start_using__r__ex.md
+++ b/content/docs/guides/start_using__r__ex.md
@@ -66,8 +66,8 @@ Now change into this directory and create a file called Rexfile with the followi
     
     desc "Get the uptime of all servers";
     task "uptime", group => "myservers", sub {
-       my $output = run "uptime";
-       say $output;
+       my $output = run "uptime";
+       say $output;
     };
     ```
 
@@ -87,7 +87,7 @@ To add a second task, just add the next lines to your Rexfile.
     ```perl
     desc "Start Apache Service";
     task "start_apache", group => "myservers", sub {
-        service "apache2" => "start";
+        service "apache2" => "start";
     };
     ```
 
@@ -98,10 +98,10 @@ If you want to display all tasks in your Rexfile use the following command.
 
     $ rex -T
     Tasks
-      start_apache                   Start Apache Service
-      uptime                         Get the uptime of all servers
+      start_apache                   Start Apache Service
+      uptime                         Get the uptime of all servers
     Server Groups
-      myservers                       mywebserver, mymailserver, myfileserver
+      myservers                       mywebserver, mymailserver, myfileserver
 
 ## Authentication
 
@@ -145,22 +145,22 @@ In this example you will learn how to install and configure ntp. You can adapt t
     group all_servers => "srv[001..150]";
 
     task "setup_ntp", group => "all_servers", sub {
-       # first we will install the package
-       pkg "ntpd",
-         ensure => "present";
+       # first we will install the package
+       pkg "ntpd",
+         ensure => "present";
 
-       # then we will upload a configuration file.
-       # the configuration file is located in a subdirectory files/etc.
-       file "/etc/ntp.conf",
-          source    => "files/etc/ntp.conf",
-          on_change => sub {
-             # we define a on_change hook, so that the ntpd server gets restarted if the file is modified.
-             service ntpd => "restart";
-          };
+       # then we will upload a configuration file.
+       # the configuration file is located in a subdirectory files/etc.
+       file "/etc/ntp.conf",
+          source    => "files/etc/ntp.conf",
+          on_change => sub {
+             # we define a on_change hook, so that the ntpd server gets restarted if the file is modified.
+             service ntpd => "restart";
+          };
 
-       # now we register the service to start at boot time.
-       service "ntpd",
-         ensure => "started";
+       # now we register the service to start at boot time.
+       service "ntpd",
+         ensure => "started";
     };
     ```
 

--- a/content/docs/guides/using_modules_and_templates.md
+++ b/content/docs/guides/using_modules_and_templates.md
@@ -28,25 +28,23 @@ This file is a normal Perl module. The only special thing is the filename, but d
     ```perl
     package Service::NTP;
     use Rex -feature => ['1.3'];
-
+    
     task prepare => sub {
-       my $service_name = case operating_system, {
-                             Debian  => "ntp",
-                             default => "ntpd",
-                          };
-       pkg "ntp",
-         ensure => "present";
-
-       file "/etc/ntp.conf",
-          source    => "files/etc/ntp.conf",
-          on_change => sub {
-             service $service_name => "restart";
-          };
-
-       service $service_name,
-         ensure => "started";
+      my $service_name = case operating_system, {
+        Debian    => "ntp",
+          default => "ntpd",
+      };
+      pkg "ntp", ensure => "present";
+    
+      file "/etc/ntp.conf",
+        source    => "files/etc/ntp.conf",
+        on_change => sub {
+        service $service_name => "restart";
+        };
+    
+      service $service_name, ensure => "started";
     };
-
+    
     1;
     ```
 
@@ -90,33 +88,31 @@ But if you want to change a parameter in your ntp.conf file you have to edit 4 f
     ```perl
     package Service::NTP;
     use Rex -feature => ['1.0'];
-
+    
     task prepare => sub {
-       my $service_name = case operating_system, {
-                             Debian  => "ntp",
-                             default => "ntpd",
-                          };
-
-       my $ntp_server   = case environment, {
-                             prod    => ["ntp01.company.tld", "ntp02.company.tld"],
-                             preprod => ["ntp01.preprod.company.tld"],
-                             test    => ["ntp01.test.company.tld"],
-                             default => ["ntp01.company.tld"],
-                          };
-
-       pkg "ntp",
-         ensure => "present";
-
-       file "/etc/ntp.conf",
-          content   => template("files/etc/ntp.conf", ntp_servers => $ntp_server),
-          on_change => sub {
-             service $service_name => "restart";
-          };
-
-       service $service_name,
-         ensure => "started";
+      my $service_name = case operating_system, {
+        Debian    => "ntp",
+          default => "ntpd",
+      };
+    
+      my $ntp_server = case environment, {
+        prod      => [ "ntp01.company.tld", "ntp02.company.tld" ],
+          preprod => ["ntp01.preprod.company.tld"],
+          test    => ["ntp01.test.company.tld"],
+          default => ["ntp01.company.tld"],
+      };
+    
+      pkg "ntp", ensure => "present";
+    
+      file "/etc/ntp.conf",
+        content   => template( "files/etc/ntp.conf", ntp_servers => $ntp_server ),
+        on_change => sub {
+        service $service_name => "restart";
+        };
+    
+      service $service_name, ensure => "started";
     };
-
+    
     1;
     ```
 
@@ -141,7 +137,7 @@ There are also some predefined variables you can use in your templates. For exam
 
     ```perl
     task "get_infos", "server01", sub {
-       dump_system_information;
+      dump_system_information;
     };
     ```
 
@@ -227,9 +223,9 @@ To use your module you have to add it to your Rexfile. This can be simply achiev
     use Rex -feature => ['1.3'];
     user "root";
     password "foo";
-
+    
     require Service::NTP;
-
+    
     1;
     ```
 

--- a/content/docs/guides/using_modules_and_templates.md
+++ b/content/docs/guides/using_modules_and_templates.md
@@ -15,10 +15,10 @@ This will create some new directories and files in your lib directory.
     .
     ├── Rexfile
     └── lib
-        └── Service
-            └── NTP
-                ├── __module__.pm
-                └── meta.yml
+        └── Service
+            └── NTP
+                ├── __module__.pm
+                └── meta.yml
 
 The meta.yml file can be ignored. This file is only important if you want to share your module on the Rex modules directory.
 
@@ -30,21 +30,21 @@ This file is a normal Perl module. The only special thing is the filename, but d
     use Rex -feature => ['1.3'];
 
     task prepare => sub {
-       my $service_name = case operating_system, {
-                             Debian  => "ntp",
-                             default => "ntpd",
-                          };
-       pkg "ntp",
-         ensure => "present";
+       my $service_name = case operating_system, {
+                             Debian  => "ntp",
+                             default => "ntpd",
+                          };
+       pkg "ntp",
+         ensure => "present";
 
-       file "/etc/ntp.conf",
-          source    => "files/etc/ntp.conf",
-          on_change => sub {
-             service $service_name => "restart";
-          };
+       file "/etc/ntp.conf",
+          source    => "files/etc/ntp.conf",
+          on_change => sub {
+             service $service_name => "restart";
+          };
 
-       service $service_name,
-         ensure => "started";
+       service $service_name,
+         ensure => "started";
     };
 
     1;
@@ -73,16 +73,16 @@ If you now want to distribute different ntp.conf files per environment you can a
     .
     ├── Rexfile
     └── lib
-        └── Service
-            └── NTP
-                ├── __module__.pm
-                ├── files
-                │   └── etc
-                │       ├── ntp.conf
-                │       ├── ntp.conf.preprod
-                │       ├── ntp.conf.prod
-                │       └── ntp.conf.test
-                └── meta.yml
+        └── Service
+            └── NTP
+                ├── __module__.pm
+                ├── files
+                │   └── etc
+                │       ├── ntp.conf
+                │       ├── ntp.conf.preprod
+                │       ├── ntp.conf.prod
+                │       └── ntp.conf.test
+                └── meta.yml
     ```
 
 But if you want to change a parameter in your ntp.conf file you have to edit 4 files. This is not realy cool. To prevent that you can use templates.
@@ -92,29 +92,29 @@ But if you want to change a parameter in your ntp.conf file you have to edit 4 f
     use Rex -feature => ['1.0'];
 
     task prepare => sub {
-       my $service_name = case operating_system, {
-                             Debian  => "ntp",
-                             default => "ntpd",
-                          };
+       my $service_name = case operating_system, {
+                             Debian  => "ntp",
+                             default => "ntpd",
+                          };
 
-       my $ntp_server   = case environment, {
-                             prod    => ["ntp01.company.tld", "ntp02.company.tld"],
-                             preprod => ["ntp01.preprod.company.tld"],
-                             test    => ["ntp01.test.company.tld"],
-                             default => ["ntp01.company.tld"],
-                          };
+       my $ntp_server   = case environment, {
+                             prod    => ["ntp01.company.tld", "ntp02.company.tld"],
+                             preprod => ["ntp01.preprod.company.tld"],
+                             test    => ["ntp01.test.company.tld"],
+                             default => ["ntp01.company.tld"],
+                          };
 
-       pkg "ntp",
-         ensure => "present";
+       pkg "ntp",
+         ensure => "present";
 
-       file "/etc/ntp.conf",
-          content   => template("files/etc/ntp.conf", ntp_servers => $ntp_server),
-          on_change => sub {
-             service $service_name => "restart";
-          };
+       file "/etc/ntp.conf",
+          content   => template("files/etc/ntp.conf", ntp_servers => $ntp_server),
+          on_change => sub {
+             service $service_name => "restart";
+          };
 
-       service $service_name,
-         ensure => "started";
+       service $service_name,
+         ensure => "started";
     };
 
     1;
@@ -141,7 +141,7 @@ There are also some predefined variables you can use in your templates. For exam
 
     ```perl
     task "get_infos", "server01", sub {
-       dump_system_information;
+       dump_system_information;
     };
     ```
 
@@ -152,11 +152,11 @@ For example this is the output of a CentOS VM
     $memory_total = '498'
     $kernelrelease = '2.6.32-220.17.1.el6.i686'
     $Kernel = {
-          kernelversion => '#1 SMP Tue May 15 22:09:39 BST 2012'
-          architecture => 'i686'
-          kernel => 'Linux'
-          kernelrelease => '2.6.32-220.17.1.el6.i686'
-       }
+          kernelversion => '#1 SMP Tue May 15 22:09:39 BST 2012'
+          architecture => 'i686'
+          kernel => 'Linux'
+          kernelrelease => '2.6.32-220.17.1.el6.i686'
+       }
     $hostname = 'c6test0232'
     $operatingsystem = 'CentOS'
     $operatingsystemrelease = '6.2'
@@ -166,30 +166,30 @@ For example this is the output of a CentOS VM
     $kernel = 'Linux'
     $swap_free = '2005'
     $VirtInfo = {
-          virtualization_role => 'guest'
-          virtualization_type => 'parallels'
-       }
+          virtualization_role => 'guest'
+          virtualization_type => 'parallels'
+       }
     $memory_shared = '0'
     $Network = {
-          networkdevices => [
-             'eth0'
-          ]
-          networkconfiguration => {
-             eth0 => {
-                broadcast => '10.211.55.255'
-                ip => '10.211.55.60'
-                netmask => '255.255.255.0'
-                mac => '00:1C:42:9E:0E:28'
-             }
-          }
-       }
+          networkdevices => [
+             'eth0'
+          ]
+          networkconfiguration => {
+             eth0 => {
+                broadcast => '10.211.55.255'
+                ip => '10.211.55.60'
+                netmask => '255.255.255.0'
+                mac => '00:1C:42:9E:0E:28'
+             }
+          }
+       }
     $memory_used = '440'
     $kernelname = 'Linux'
     $Swap = {
-          free => '2005'
-          used => '10'
-          total => '2015'
-       }
+          free => '2005'
+          used => '10'
+          total => '2015'
+       }
     $swap_total = '2015'
     $memory_buffers = '47'
     $eth0_ip = '10.211.55.60'
@@ -197,23 +197,23 @@ For example this is the output of a CentOS VM
     $memory_free = '57'
     $manufacturer = 'Parallels Software International Inc.'
     $Memory = {
-          shared => '0'
-          buffers => '47'
-          free => '57'
-          used => '440'
-          total => '498'
-          cached => '357'
-       }
+          shared => '0'
+          buffers => '47'
+          free => '57'
+          used => '440'
+          total => '498'
+          cached => '357'
+       }
     $eth0_broadcast = '10.211.55.255'
     $eth0_netmask = '255.255.255.0'
     $Host = {
-          domain => 'test.rexify.org'
-          manufacturer => 'Parallels Software International Inc.'
-          kernelname => 'Linux'
-          hostname => 'c6test0232'
-          operatingsystemrelease => '6.2'
-          operatingsystem => 'CentOS'
-       }
+          domain => 'test.rexify.org'
+          manufacturer => 'Parallels Software International Inc.'
+          kernelname => 'Linux'
+          hostname => 'c6test0232'
+          operatingsystemrelease => '6.2'
+          operatingsystem => 'CentOS'
+       }
 
 You can use such predefined variable right in your template. Lets assume you want to bind apache only on your eth1 ip.
 
@@ -238,6 +238,6 @@ Than you can list your Tasks and execute them.
     $ rex -T
     [2013-03-30 02:35:32] INFO - eval your Rexfile.
     Tasks
-      Service:NTP:prepare
+      Service:NTP:prepare
 
     $ rex -H yourserver01 Service:NTP:prepare

--- a/content/docs/guides/working_with_packages.md
+++ b/content/docs/guides/working_with_packages.md
@@ -11,8 +11,7 @@ To install a package you can use the `pkg` function.
 
     ```perl
     task "prepare", "server1", sub {
-      pkg "apache2",
-        ensure => "present";
+      pkg "apache2", ensure => "present";
     };
     ```
 
@@ -20,8 +19,7 @@ If you want to install multiple packages you can do it by providing an array ref
 
     ```perl
     task "prepare", "server1", sub {
-      pkg [ qw/apache2 vim php5/ ],
-        ensure => "present";
+      pkg [qw/apache2 vim php5/], ensure => "present";
     };
     ```
 
@@ -29,8 +27,7 @@ If you want to install a special version of a package you just need to specify t
 
     ```perl
     task "prepare", "server1", sub {
-      pkg "apache2",
-        ensure => "2.2.4";
+      pkg "apache2", ensure => "2.2.4";
     };
     ```
 
@@ -40,8 +37,7 @@ If you don't need a package anymore you can remove it with the remove function.
 
     ```perl
     task "prepare", "server1", sub {
-      pkg "apache2",
-        ensure => "absent";
+      pkg "apache2", ensure => "absent";
     };
     ```
 
@@ -53,11 +49,13 @@ Sometimes you have to add custom repositories to your Server. This can be done w
 
     ```perl
     task "prepare", "server2", sub {
-       # add a repository for debian/ubuntu
-       repository add => "myrepo",
-          url => "http://foo.bar/repo",
-          distro => "squeeze",
-          repository => "stable";
+    
+      # add a repository for debian/ubuntu
+      repository
+        add        => "myrepo",
+        url        => "http://foo.bar/repo",
+        distro     => "squeeze",
+        repository => "stable";
     };
     ```
 
@@ -65,9 +63,11 @@ Sometimes you have to add custom repositories to your Server. This can be done w
 
     ```perl
     task "prepare", "server2", sub {
-       # add a repository for redhat/centos
-       repository add => "myrepo",
-          url => "http://foo.bar/repo";
+    
+      # add a repository for redhat/centos
+      repository
+        add => "myrepo",
+        url => "http://foo.bar/repo";
     };
     ```
 
@@ -75,12 +75,14 @@ After you've added a new repository you need to run update\_package\_db to updat
 
     ```perl
     task "prepare", "server2", sub {
-       # add a repository for redhat/centos
-       repository add => "myrepo",
-          url => "http://foo.bar/repo";
-           
-       # update package database
-       update_package_db;
+    
+      # add a repository for redhat/centos
+      repository
+        add => "myrepo",
+        url => "http://foo.bar/repo";
+    
+      # update package database
+      update_package_db;
     };
     ```
 

--- a/content/docs/guides/working_with_packages.md
+++ b/content/docs/guides/working_with_packages.md
@@ -11,7 +11,7 @@ To install a package you can use the `pkg` function.
 
     ```perl
     task "prepare", "server1", sub {
-      pkg "apache2",
+      pkg "apache2",
         ensure => "present";
     };
     ```
@@ -20,7 +20,7 @@ If you want to install multiple packages you can do it by providing an array ref
 
     ```perl
     task "prepare", "server1", sub {
-      pkg [ qw/apache2 vim php5/ ],
+      pkg [ qw/apache2 vim php5/ ],
         ensure => "present";
     };
     ```
@@ -29,7 +29,7 @@ If you want to install a special version of a package you just need to specify t
 
     ```perl
     task "prepare", "server1", sub {
-      pkg "apache2",
+      pkg "apache2",
         ensure => "2.2.4";
     };
     ```
@@ -40,7 +40,7 @@ If you don't need a package anymore you can remove it with the remove function.
 
     ```perl
     task "prepare", "server1", sub {
-      pkg "apache2",
+      pkg "apache2",
         ensure => "absent";
     };
     ```
@@ -53,11 +53,11 @@ Sometimes you have to add custom repositories to your Server. This can be done w
 
     ```perl
     task "prepare", "server2", sub {
-       # add a repository for debian/ubuntu
-       repository add => "myrepo",
-          url => "http://foo.bar/repo",
-          distro => "squeeze",
-          repository => "stable";
+       # add a repository for debian/ubuntu
+       repository add => "myrepo",
+          url => "http://foo.bar/repo",
+          distro => "squeeze",
+          repository => "stable";
     };
     ```
 
@@ -65,9 +65,9 @@ Sometimes you have to add custom repositories to your Server. This can be done w
 
     ```perl
     task "prepare", "server2", sub {
-       # add a repository for redhat/centos
-       repository add => "myrepo",
-          url => "http://foo.bar/repo";
+       # add a repository for redhat/centos
+       repository add => "myrepo",
+          url => "http://foo.bar/repo";
     };
     ```
 
@@ -75,12 +75,12 @@ After you've added a new repository you need to run update\_package\_db to updat
 
     ```perl
     task "prepare", "server2", sub {
-       # add a repository for redhat/centos
-       repository add => "myrepo",
-          url => "http://foo.bar/repo";
-           
-       # update package database
-       update_package_db;
+       # add a repository for redhat/centos
+       repository add => "myrepo",
+          url => "http://foo.bar/repo";
+           
+       # update package database
+       update_package_db;
     };
     ```
 

--- a/content/docs/release_notes/0.10.md
+++ b/content/docs/release_notes/0.10.md
@@ -8,13 +8,13 @@ title: Release notes for 0.10
 
         ```perl
         use Rex::Commands::Network;
-
+        
         my @routes = route;
         print Dumper( \@routes );
-
+        
         my $default_gw = default_gateway;
         default_gateway "192.168.2.1";
-
+        
         my @netstat         = netstat;
         my @tcp_connections = grep { $_->{"proto"} eq "tcp" } netstat;
         ```
@@ -28,7 +28,7 @@ title: Release notes for 0.10
             fs      => "ext3",
             options => [qw/noatime async/];
         };
-
+        
         task "umount", "server01", sub {
           umount "/tmp";
         };
@@ -38,7 +38,7 @@ title: Release notes for 0.10
 
         ```perl
         use Rex::Commands::Cron;
-
+        
         cron
           add => "root",
           {
@@ -48,9 +48,9 @@ title: Release notes for 0.10
           month        => '*',
           day_of_week  => '*',
           };
-
+        
         cron list => "root";
-
+        
         cron delete => "root", 3;
         ```
 
@@ -64,12 +64,12 @@ title: Release notes for 0.10
 
         ```perl
         task "get-installed", "server1", sub {
-
+        
           for my $pkg ( installed_packages() ) {
             say "name     : " . $pkg->{"name"};
             say "  version: " . $pkg->{"version"};
           }
-
+        
         };
     ```
 

--- a/content/docs/release_notes/0.11.md
+++ b/content/docs/release_notes/0.11.md
@@ -8,7 +8,7 @@ title: Release notes for 0.11
 
         ```perl
         use Rex::Commands::LVM;
-
+        
         task "lvm", sub {
           my @physical_devices = pvs;
           my @volume_groups    = vgs;

--- a/content/docs/release_notes/0.12.md
+++ b/content/docs/release_notes/0.12.md
@@ -8,7 +8,7 @@ title: Release notes for 0.12
 
         ```perl
         sudo_password "mypassword";
-
+        
         task "dosomething", sub {
           say sudo "id";
         };
@@ -36,41 +36,41 @@ title: Release notes for 0.12
 
         ```perl
         task "firewall", sub {
-
+        
           # clear all rules
           iptables_clear;
-
+        
           # open port 22 on all devices
           open_port 22;
-
+        
           # open port 22 and 80 on eth0
           open_port [ 22, 80 ] => { dev => "eth0", };
-
+        
           # close all ports on all devices
           close_port "all";
-
+        
           # close port 22 on dev eth0
           close_port 22 => { dev => "eth0", };
-
+        
           # redirect port 80 to 10080
           redirect_port 80 => 10080;
-
+        
           # redirect port 80 to 10080 on eth0
           redirect_port 80 => {
             dev => "eth0",
             to  => 10080,
           };
-
-        # set default state rules (RELATED,ESTABLISHED) to accept on all devices
+        
+          # set default state rules (RELATED,ESTABLISHED) to accept on all devices
           default_state_rule;
-
+        
           # set default state rules (RELATED,ESTABLISHED) to accept on eth0
           default_state_rule dev => "eth0";
-
+        
           # make the system a nat gateway for its default route
           # this will set the sysctl entry net.ipv4.ip_forward to 1, too.
           is_nat_gateway;
-
+        
           # define a custom iptables rule
           iptables t => "filter", A => "INPUT", i => "eth0", ...;
         };
@@ -81,37 +81,36 @@ title: Release notes for 0.12
         ```perl
         use Data::Dumper;
         use Rex::Commands::Cloud;
-
+        
         user "root";
         public_key "/path/to/your/ec2-public.key";
         private_key "/path/to/your/ec2-private.key.pem";
-
+        
         # set the cloud service provider to "Amazon"
         cloud_service "Amazon";
-
+        
         # set cloud auth
         cloud_auth "$access_key", "$secret_access_key";
-
+        
         # set cloud region
         cloud_region "ec2.eu-west-1.amazonaws.com";
-
+        
         # define a group with all running ec2 instances
         group ec2 => get_cloud_instances_as_group();
-
+        
         task "list", sub {
           print Dumper cloud_instances_list;
           print Dumper cloud_volume_list;
-
+        
           print Dumper get_cloud_regions;
           print Dumper get_cloud_availability_zones;
         };
-
+        
         task "create", sub {
-
+        
           # if you want an ebs volume, create it. if not, you don't need this.
-          my $vol_id =
-            cloud_volume create => { size => 1, zone => "eu-west-1a"; };
-
+          my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a"; };
+        
           # create the cloud instances and attach the just created ebs volume.
           cloud_instance create => {
             image_id => "ami-02103876",
@@ -121,13 +120,13 @@ title: Release notes for 0.12
             zone => "eu-west-1a", # the volume and the instance must be in the same zone. skip this if you don't have a volume.
           };
         };
-
+        
         task "destroy", sub {
           cloud_volume detach      => "vol-xxaabb";
           cloud_instance terminate => "i-ffgghhjj";
           cloud_colume delete      => "vol-xxaabb";
         };
-
+        
         task "prepare",
           group => "ec2",
           sub {

--- a/content/docs/release_notes/0.13.md
+++ b/content/docs/release_notes/0.13.md
@@ -12,16 +12,16 @@ title: Release notes for 0.13
 
         ```perl
         use Rex::Commands::Cloud;
-
+        
         user "root";
         password "f00b4r";
         pass_auth;
-
+        
         cloud_service "Jiffybox";
         cloud_auth "yourkey";
-
+        
         group jiffybox => get_cloud_instances_as_group();
-
+        
         task "create", sub {
           cloud_instance create => {
             image_id => "debian_squeeze_64bit",
@@ -30,7 +30,7 @@ title: Release notes for 0.13
             password => "f00b4r",
           };
         };
-
+        
         task "prepare",
           group => "jiffybox",
           sub {
@@ -54,11 +54,11 @@ title: Release notes for 0.13
         ```perl
         task "test", "server1", "server2", sub {
           unlink "/tmp/doesntexists"; # this will terminate the whole execution because it will fail.
-
+        
           # this will catch the exception and store it in $@
           eval {
             unlink "/tmp/doesntexists";
-
+        
             # and more stuff
           } or do {
             say "Tried to unlink /tmp/doesntexists but it failed.";

--- a/content/docs/release_notes/0.17.md
+++ b/content/docs/release_notes/0.17.md
@@ -19,9 +19,9 @@ title: Release notes for 0.17
         ```perl
         # in the base section of your Rexfile
         package_provider_for SunOS => "Blastwave";
-
+        
         task "prepare", "server1", "server2", sub {
-
+        
           # if solaris, install apache-22 from Blastwave
           install package => "apache-22";
         };
@@ -32,9 +32,9 @@ title: Release notes for 0.17
         ```perl
         # in the base section of your Rexfile
         package_provider_for SunOS => "OpenCSW";
-
+        
         task "prepare", "server1", "server2", sub {
-
+        
           # if solaris, install apache-22 from OpenCSW
           install package => "apache-22";
         };
@@ -67,7 +67,7 @@ title: Release notes for 0.17
         ```perl
         # in the base section of your Rexfile
         service_provider_for SunOS => "svcadm";
-
+        
         task "prepare-services", "server1", "server2", sub {
           service ssh => "restart";
         };

--- a/content/docs/release_notes/0.19.md
+++ b/content/docs/release_notes/0.19.md
@@ -19,26 +19,26 @@ title: Release notes for 0.19
         user "root";
         password "foobar";
         pass_auth;
-
+        
         # define default frontend group containing only testwww01
         group frontend => "testwww01";
-
+        
         # define live environment, with different user/password
         # and a frontend server group containing www01, www02 and www03
         environment live => sub {
           user "root";
           password "livefoo";
           pass_auth;
-
+        
           group frontend => "www01", "www02", "www03";
         };
-
+        
         # define stage environment with default user and password, but with
         # an own frontend group containing only stagewww01
         environment stage => sub {
           group frontend => "stagewww01";
         };
-
+        
         task "prepare",
           group => "frontend",
           sub {

--- a/content/docs/release_notes/0.21.md
+++ b/content/docs/release_notes/0.21.md
@@ -12,7 +12,7 @@ title: Release notes for 0.21
         set
           repository => "myrepo",
           url        => "git@foo.bar:myrepo.git";
-
+        
         task "checkout", sub {
           checkout "myrepo";
         };
@@ -25,7 +25,7 @@ title: Release notes for 0.21
         ```perl
         group "frontend" => "fe01", "fe02";
         group "backend"  => "be01", "be02";
-
+        
         task "prepare",
           group => [ "frontend", "backend" ],
           sub {
@@ -38,22 +38,22 @@ title: Release notes for 0.21
         ```perl
         user "root";
         password "test";
-
+        
         task "prepare", "server1", sub {
-
+        
           # will authenticate as root/test
         };
-
+        
         task "prepare2", "server1", sub {
-
+        
           # will also authenticate as root/test
         };
-
+        
         # all tasks from here down will authenticate as deploy/testdeploy
         user "deploy";
         password "testdeploy";
         task "deploy", "server1", sub {
-
+        
           # will authenticate as deploy/testdeploy
         };
         ```
@@ -83,7 +83,7 @@ title: Release notes for 0.21
         ```perl
         port 2222;
         task "prepare", "server1", "server2", sub {
-
+        
           # will always connect to port 2222
         };
         ```

--- a/content/docs/release_notes/0.22.md
+++ b/content/docs/release_notes/0.22.md
@@ -10,16 +10,16 @@ title: Release notes for 0.22
           task
             prepare => "server1",
             "server2", sub {
-
+          
             # do something
             };
-
+          
           before prepare => sub {
             my ($server) = @_;
             say "Starting virtual machine...";
             run "xm start $server";
           };
-
+          
           after prepare => sub {
             my ( $server, $failed_connection ) = @_;
             say "Stopping virtual machine...";
@@ -35,14 +35,14 @@ title: Release notes for 0.22
 
           ```perl
           task prepare_user => sub {
-
+          
             create_user "foo" => {
               home           => '/home/foo',
               groups         => [ 'users', '...' ],
               crypt_password => '$1$.yBAfj8a$mQ2SY/lfz8FaSUTgHsP37c/',
               ssh_key        => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChUw...",
             };
-
+          
           };
           ```
 

--- a/content/docs/release_notes/0.24.md
+++ b/content/docs/release_notes/0.24.md
@@ -11,19 +11,19 @@ title: Release notes for 0.24
         use Rex::Commands::Run;
         use Rex::Commands::Fs;
         use Rex::Commands::Pkg;
-
+        
         Rex::connect(
           server      => "remotehost",
           user        => "root",
           private_key => "/home/jan/.ssh/id_rsa",
           public_key  => "/home/jan/.ssh/id_rsa.pub",
         );
-
+        
         if ( is_file("/etc/sudoers") ) {
-
+        
           # do something
         }
-
+        
         install package => "apache2";
         ```
 
@@ -40,10 +40,9 @@ title: Release notes for 0.24
 
         ```perl
         task "foo", sub {
-          file "/etc/foo",
-            content => template( "@mytemplate.conf", user => 'bar', );
+          file "/etc/foo", content => template( "@mytemplate.conf", user => 'bar', );
         };
-
+        
          __DATA__
          @mytemplate.conf
          <?php
@@ -58,13 +57,13 @@ title: Release notes for 0.24
         ```perl
         task "foo", sub {
           my ($param) = shift;
-
+        
           # ...
         };
-
+        
         before foo => sub {
           my ( $server, $server_ref, $param ) = @_;
-
+        
           # do something before "foo"
         };
         ```

--- a/content/docs/release_notes/0.26.md
+++ b/content/docs/release_notes/0.26.md
@@ -12,7 +12,7 @@ title: Release notes for 0.26
         user "unprivuser";
         sudo_password "f00b4r";
         sudo -on; # turn sudo globally on
-
+        
         task prepare => sub {
           install "apache2";
           file "/etc/ntp.conf",
@@ -28,7 +28,7 @@ title: Release notes for 0.26
         task prepare => sub {
           file "/tmp/foo.txt",
             content => "this file was written without sudo privileges\n";
-
+        
           # everything in this section will be executed with sudo privileges
           sudo sub {
             install "apache2";
@@ -42,7 +42,7 @@ title: Release notes for 0.26
 
         ```perl
         include qw/Webserver::Apache Database::MySQL/;
-
+        
         task prepare => sub {
           Webserver::Apache::setup();
         };
@@ -61,7 +61,7 @@ title: Release notes for 0.26
         ```perl
         task prepare => sub {
           install "foo";
-
+        
           # old way
           install package => "foo";
         };

--- a/content/docs/release_notes/0.3.md
+++ b/content/docs/release_notes/0.3.md
@@ -10,17 +10,17 @@ title: Release notes for 0.3
 
         ```perl
         use Rex::Commands::Rsync;
-
+        
         desc "Sync /etc";
         task "etc", "server1", "server2", "server3", sub {
           sync "/filestore/public/etc", "/etc";
         };
-
-    Or, if you want to sync a remote directory to a local one
-
-        task "get-logs", "server", sub {
+        
+        Or, if you want to sync a remote directory to a local one
+        
+          task "get-logs", "server", sub {
           sync "/var/log", "/tmp/logs", { download => 1 };
-        };
+          };
         ```
 
 -   **Debug mode**
@@ -51,8 +51,8 @@ title: Release notes for 0.3
         task "uname", "www[1..10]", sub {
           run "uname -a";
         };
-
-    or
+        
+          or
 
         ```perl
         group "webserver" => "www[01..15]", "web[1..3]";
@@ -88,7 +88,7 @@ title: Release notes for 0.3
           run "hostname";
           do_task "uname";
         };
-
+        
         task "uname", "server1", "server2", sub {
           run "uname -a";
         };

--- a/content/docs/release_notes/0.30.md
+++ b/content/docs/release_notes/0.30.md
@@ -9,7 +9,7 @@ title: Release notes for 0.30
         ```perl
         # to get a list of all users
         my @users = user_list();
-
+        
         # to get the groups of user "foo"
         my @groups = user_groups("foo");
         ```

--- a/content/docs/release_notes/0.31.md
+++ b/content/docs/release_notes/0.31.md
@@ -19,10 +19,10 @@ title: Release notes for 0.31
         ```perl
         # Rexfile
         use Rex -feature => 0.31;
-
+        
         user "root";
         password "foo";
-
+        
         task prepare => sub {
         };
         ```
@@ -35,24 +35,24 @@ title: Release notes for 0.31
 
         ```perl
         use Rex -feature => 0.31;
-
+        
         group frontends => "web[01..10]";
         group backends  => "be[01..05]";
-
+        
         auth for   => "frontends" => user => "root",
           password => "foobar";
-
+        
         auth for      => "backends" => user => "admin",
           private_key => "/path/to/id_rsa",
           public_key  => "/path/to/id_rsa.pub",
           sudo        => TRUE;
-
+        
         task "prepare",
           group => [ "frontends", "backends" ],
           sub {
           # do something
           };
-
+        
         auth for => "prepare" => user => "root";
         ```
 

--- a/content/docs/release_notes/0.33.md
+++ b/content/docs/release_notes/0.33.md
@@ -55,23 +55,23 @@ title: Release notes for 0.33
         ```perl
         # old
         task prepare => sub {
-
+        
           # do something
         };
-
+        
         # new
         task prepare => make {
-
+        
           # do something
         };
-
+        
         # old
         task "prepare",
           group => "foo",
           sub {
           # do something
           };
-
+        
         # new
         task "prepare",
           group => "foo",
@@ -108,9 +108,9 @@ title: Release notes for 0.33
         # Rexfile
         use strict;
         use warnings;
-
+        
         use Template;
-
+        
         set template_function => sub {
           my ( $content, $vars ) = @_;
           my $t = Template->new;
@@ -118,7 +118,7 @@ title: Release notes for 0.33
           $t->process( \$content, $vars, \$out );
           return $out;
         };
-
+        
         task foo => sub {
           file "/etc/foo/service.conf",
             content => template(

--- a/content/docs/release_notes/0.35.md
+++ b/content/docs/release_notes/0.35.md
@@ -18,30 +18,30 @@ A website where you can download prebuilt Boxes and find information about Rex/B
 
         ```perl
         use Rex::Commands::Virtualization;
-
+        
         set virtualization => "VBox";
-
+        
         use Data::Dumper;
-
+        
         print Dumper vm list => "all";
         print Dumper vm list => "running";
-
+        
         vm destroy => "vm01";
-
+        
         vm delete => "vm01";
-
+        
         vm start => "vm01";
-
+        
         vm shutdown => "vm01";
-
+        
         vm reboot => "vm01";
-
+        
         vm
           option => "vm01",
           memory => 512;
-
+        
         print Dumper vm info => "vm01";
-
+        
         # creating a vm
         vm
           create  => "vm01",
@@ -62,11 +62,11 @@ Functions to easily work with VirtualBox images.
 
     ```perl
     use Rex::Commands::Box;
-
+    
     task "init", sub {
-
+    
       my $param = shift;
-
+    
       box {
         my ($box) = @_;
         $box->name( $param->{name} );
@@ -76,32 +76,32 @@ Functions to easily work with VirtualBox images.
             type => "nat",
           }
         );
-
+    
         # only works with network type = nat
         # if an ssh key is present, rex will use this to log into the vm
         # you need this if you don't run VirtualBox on your local host.
         $box->forward_port( ssh => [ 2222 => 22 ] );
-
+    
         $box->share_folder( "myhome" => "/home/jan" );
-
+    
         $box->auth(
           user     => "root",
           password => "box",
         );
-
+    
         $box->setup(qw/install_webserver/);
       };
-
+    
     };
-
+    
     task "down", sub {
-
+    
       my $param = shift;
-
+    
       my $box = Rex::Commands::Box->new( name => $param->{name} );
       $box->stop;
     };
-
+    
     task "install_webserver", sub {
       install "apache2";
     };
@@ -111,14 +111,14 @@ Functions to easily work with VirtualBox images.
 
         ```perl
         # Rexfile
-    
+        
         task foo => sub {
         };
         task example => sub {
         };
         task example2 => sub {
         };
-    
+        
         set auth for qr{^example\d$} => user => "example",
           password => "foob4r";
         ```
@@ -157,7 +157,7 @@ It is also possible to add an **after** hook like this:
           distro     => "precise",
           repository => "foo",
           after      => sub {
-
+    
             # import gpg key
           },
         },
@@ -166,14 +166,14 @@ It is also possible to add an **after** hook like this:
           distro     => "squeeze",
           repository => "foo",
           after      => sub {
-
+    
             # import gpg key
           },
         },
         CentOS => {
           url   => "http://foo.bar/repo",
           after => sub {
-
+    
             # import gpg key
           },
         },

--- a/content/docs/release_notes/0.36.md
+++ b/content/docs/release_notes/0.36.md
@@ -9,50 +9,50 @@ title: Release notes for 0.36
 You can download OpenNebula module with the following command:
 
     ```perl
-    bash# rexify --use Rex::Cloud::OpenNebula
-
-    use strict;
+    bash # rexify --use Rex::Cloud::OpenNebula
+    
+      use strict;
     use warnings;
-
+    
     use Rex::Commands::Cloud;
     use Rex::Cloud::OpenNebula;
     use Data::Dumper;
-
+    
     user "root";
-
+    
     cloud_service "OpenNebula";
     cloud_auth "oneadmin", "opennebula";
     cloud_region "http://172.16.120.131:2633/RPC2";
-
+    
     task "list-os", sub {
       print Dumper get_cloud_operating_systems;
     };
-
+    
     task "create", sub {
       my $params = shift;
       my $vm     = cloud_instance create => {
         image => "template-1",
         name  => $params->{name},
       };
-
+    
       print Dumper($vm);
     };
-
+    
     task "start", sub {
       my $params = shift;
       cloud_instance start => $params->{name};
     };
-
+    
     task "stop", sub {
       my $params = shift;
       cloud_instance stop => $params->{name};
     };
-
+    
     task "terminate", sub {
       my $params = shift;
       cloud_instance terminate => $params->{name};
     };
-
+    
     task "list", sub {
       print Dumper cloud_instance_list;
     };
@@ -64,18 +64,18 @@ With this function you can run a specific task on a given host and get the outpu
 
     ```perl
     task "prepare", "server5", sub {
-
+    
       # do something
       my $free_mem = run_task "get_free_mem", on => "server3";
       if ( $free_mem < 100 ) {
         say "Less than 100 MB free mem on server3";
-
+    
         # create a new server instance on server5 to unload server3
       }
     };
-
+    
     task "get_free_mem", sub {
-        return memory->{free};
+      return memory->{free};
     };
     ```
 

--- a/content/docs/release_notes/0.37.md
+++ b/content/docs/release_notes/0.37.md
@@ -14,30 +14,30 @@ You can use thise module by installing it via *rexify*.
 
     ```perl
     # From within a project
-    bash# rexify --use=Rex::DNS:Bind
-
-    # To create a new project
-    bash# rexify mynewproject --use=Rex::DNS::Bind
-
-    set dns => {
+    bash # rexify --use=Rex::DNS:Bind
+    
+      # To create a new project
+      bash # rexify mynewproject --use=Rex::DNS::Bind
+    
+      set dns => {
       server   => "127.0.0.1",
       key_name => "mysuperkey",
       key      => "/foobar==",
-    };
-
+      };
+    
     task sometask => sub {
       Rex::DNS::Bind::add_record(
         domain => "rexify.org",
         host   => "foobar01",
         data   => "127.0.0.4",
       );
-
+    
       Rex::DNS::Bind::delete_record(
         domain => "rexify.org",
         host   => "foobar01",
         type   => "A",
       );
-
+    
       my @entries = Rex::DNS::Bind::list_entries( domain => "rexify.org" );
       print Dumper( \@entries );
     };
@@ -53,7 +53,7 @@ See [Rex::DNS::Bind](http://modules.rexify.org/module/Rex::DNS::Bind) for the AP
             on     => "foo",
             params => { key1 => "value1", key2 => "value2" };
         };
-    
+        
         task "tasktwo", sub {
           my $param = shift;
           print Dumper($param);

--- a/content/docs/release_notes/0.38.md
+++ b/content/docs/release_notes/0.38.md
@@ -81,15 +81,15 @@ title: Release notes for 0.38
 
         ```perl
         task "prepare_boxes", sub {
-
+        
           # this will create a defined boxes from the YAML file.
           boxes "init";
         };
-
+        
         task "stop_boxes", sub {
           boxes stop => qw/box1 box2/;
         };
-
+        
         task "start_boxes", sub {
           boxes start => qw/box1 box2/;
         };

--- a/content/docs/release_notes/0.4.md
+++ b/content/docs/release_notes/0.4.md
@@ -11,11 +11,11 @@ title: Release notes for 0.4
         ```perl
         use Rex::Hardware;
         use Data::Dumper;
-
+        
         desc "Get Hardware Information";
         task "hw-info", "testsystem", sub {
           my %hw = Rex::Hardware->get(qw/ Host Kernel Memory Network Swap /);
-
+        
           print Dumper( \%hw );
         };
         ```
@@ -79,26 +79,26 @@ title: Release notes for 0.4
         ```perl
         # include for ,,install'' Function
         use Rex::Commands::Pkg;
-
+        
         # include for ,,operating_system_is'' Function
         use Rex::Commands::Gather;
-
+        
         user "root";
-
+        
         private_key "/Users/jan/.ssh/id_rsa";
         public_key "/Users/jan/.ssh/is_rsa.pub";
-
+        
         # group servers
         group "test" => "debian01", "centos01", "suse01";
-
+        
         # run tasks in parallel
         parallelism 2;
-
+        
         desc "Prepare System";
         task "prepare",
           group => "test",
           sub {
-
+        
           # check if operating system is CentOS, because on CentOS vim is
           # available through the package "vim-enhanced".
           if ( operating_system_is("CentOS") ) {
@@ -107,9 +107,9 @@ title: Release notes for 0.4
           else {
             install package => "vim";
           }
-
+        
           install package => "mc";
-
+        
           };
         ```
 

--- a/content/docs/release_notes/0.40.md
+++ b/content/docs/release_notes/0.40.md
@@ -11,12 +11,12 @@ The first CMDB module is based on YAML files. With this change there will be als
     ```perl
     use Cwd 'getcwd';
     use Rex::CMDB;
-
+    
     set cmdb => {
       type => "YAML",
       path => getcwd() . "/cmdb",
     };
-
+    
     task "prepare", sub {
       my $vhosts = get cmdb "vhosts";
     };
@@ -40,7 +40,7 @@ It is now possible to use VirtualBox in headless mode on MacOSX and Linux.
       type     => "VBox",
       headless => TRUE
     };
-
+    
     task "foo", sub {
       vm start => "myvm";
     };

--- a/content/docs/release_notes/0.41.md
+++ b/content/docs/release_notes/0.41.md
@@ -29,19 +29,19 @@ This module doesn't use rsync, so it works with sudo and Windows, too. And it is
 
     ```perl
     task "prepare", "mysystem01", sub {
-
+    
       # upload directory recursively to remote system.
       sync_up "/local/directory", "/remote/directory";
-
+    
       sync_up "/local/directory", "/remote/directory", {
-
+    
         # setting custom file permissions for every file
         files => {
           owner => "foo",
           group => "bar",
           mode  => 600,
         },
-
+    
         # setting custom directory permissions for every directory
         directories => {
           owner => "foo",
@@ -49,7 +49,7 @@ This module doesn't use rsync, so it works with sudo and Windows, too. And it is
           mode  => 700,
         },
       };
-
+    
       # download a directory recursively from the remote system to the local machine
       sync_down "/remote/directory", "/local/directory";
     };
@@ -70,7 +70,7 @@ To get the hypervisor:
     ```perl
     task "info", "mysystem01", sub {
       my %hw_info = Rex::Hardware->get(qw/VirtInfo/);
-
+    
       say "Role: " . $hw_info{VirtInfo}->{virtualization_role};
       say "Type: " . $hw_info{VirtInfo}->{virtualization_type};
     };
@@ -85,7 +85,7 @@ To get the hypervisor:
               CentOS  => "vim-enhanced",
               default => "vim",
           };
-
+        
           install $package;
         };
         ```

--- a/content/docs/release_notes/0.42.md
+++ b/content/docs/release_notes/0.42.md
@@ -14,9 +14,9 @@ This fixes long standing pull request \#70.
 
     ```perl
     use Rex -feature => '0.42';
-
+    
     set connection => 'OpenSSH';
-
+    
     task 'yourtask', 'yourserver', sub {
       say run 'uptime';
     };
@@ -28,7 +28,7 @@ If you want to use kerberos authentication you have to use Net::OpenSSH.
 
     ```perl
     set connection => "OpenSSH";
-
+    
     user "youruser";
     krb5_auth;
     ```

--- a/content/docs/release_notes/0.43.md
+++ b/content/docs/release_notes/0.43.md
@@ -16,7 +16,7 @@ You can also set the cache type inside your *Rexfile*
 
     ```perl
     # Rexfile
-
+    
     user "root";
     password "...";
     cache "YAML";
@@ -99,7 +99,7 @@ rex will now only upload a file if it really changes and it will upload the file
         user "foo";
         password "b4r";
         tmp_dir "/home/foo/tmp";
-
+        
         task "mytask", "myserver", sub {
         };
         ```

--- a/content/docs/release_notes/0.44.md
+++ b/content/docs/release_notes/0.44.md
@@ -10,7 +10,7 @@ title: Release notes for 0.44
 
         ```perl
         sayformat '%h: %s';
-
+        
         task "test", sub {
           say "hello world";
         };
@@ -56,7 +56,7 @@ For example:
     ```perl
     use Rex::Hook;
     use Data::Dumper;
-
+    
     register_function_hooks {
       before => {
         file => sub {
@@ -86,7 +86,7 @@ For example:
         sync_up "files/", "/remote/folder", {
           on_change => sub {
             my (@changed_files) = @_;
-
+        
             # do something
           };
         };
@@ -119,7 +119,7 @@ For example:
         ```perl
         # Rexfile
         use Rex -feature => ['no_path_cleanup'];
-
+        
         task prepare => sub { };
         ```
 
@@ -128,7 +128,7 @@ For example:
         ```perl
         # Rexfile
         use Rex -feature => ['source_profile'];
-
+        
         task prepare => sub { };
         ```
 
@@ -139,7 +139,7 @@ For example:
         ```perl
         # Rexfile
         use Rex -feature => ['exec_autodie'];
-
+        
         task "prepare", sub {
           run "this-command-fails";
         };
@@ -181,9 +181,9 @@ For example:
 
         ```perl
         include qw/Rex::Ext::Backup/;
-
+        
         set backup_location => "backup/%h";
-
+        
         task yourtask => sub {
           file "/etc/foo.conf", content => "new content\n";
         };

--- a/content/docs/release_notes/0.45.md
+++ b/content/docs/release_notes/0.45.md
@@ -27,7 +27,7 @@ Changes in the Cloud API
 
             ```perl
             my $vol_id = cloud_volume create => { size => 1, zone => "nova", };
-
+            
             my $instance = cloud_instance create => {
               image_id => "ccd8bcab-8ad2-4744-8227-08279fab7a42",
               name     => "ostack01",
@@ -58,9 +58,9 @@ Changes in the core. These include new resources and new options for existing on
 
             ```perl
             file "/var/named/$zone->{name}.zone",
-              content => template( '@zone-file.tpl', conf => $conf, %{$zone} ),
-              owner   => "named",
-              group   => "named",
+              content      => template( '@zone-file.tpl', conf => $conf, %{$zone} ),
+              owner        => "named",
+              group        => "named",
               no_overwrite => TRUE;
             ```
 
@@ -81,10 +81,8 @@ Changes in the core. These include new resources and new options for existing on
 
             ```perl
             file [
-              "/etc/rex/io/inventory/bootdevice",
-              "/etc/rex/io/inventory/bridge",
-              "/etc/rex/io/inventory/sysinfo",
-              "/etc/rex/io/inventory/os"
+              "/etc/rex/io/inventory/bootdevice", "/etc/rex/io/inventory/bridge",
+              "/etc/rex/io/inventory/sysinfo",    "/etc/rex/io/inventory/os"
               ],
               owner => "root",
               group => "root",
@@ -101,7 +99,7 @@ Changes in the core. These include new resources and new options for existing on
             run "kill-process-httpd",
               command       => "killall -KILL httpd",
               only_notified => TRUE;
-
+            
             # somewhere else in the code
             notify run => "kill-process-httpd";
             ```
@@ -146,7 +144,7 @@ Changes in the core. These include new resources and new options for existing on
 
             ```perl
             service "httpd", ensure => "running";
-
+            
             # somewhere else in the code
             file "/etc/httpd/httpd.conf",
               content   => template( "templates/httpd.conf.tpl", %vars ),

--- a/content/docs/release_notes/0.46.md
+++ b/content/docs/release_notes/0.46.md
@@ -24,30 +24,30 @@ To create a test just create a new file inside a *t* directory: *t/base.t*.
     use Rex::Test::Base;
     use Data::Dumper;
     use Rex -base;
-
+    
     test {
       my $t = shift;
-
+    
       $t->name("ubuntu test");
-
+    
       $t->base_vm("http://box.rexify.org/box/ubuntu-server-12.10-amd64.ova");
       $t->vm_auth( user => "root", password => "box" );
-
+    
       $t->run_task("setup");
-
+    
       $t->has_package("vim");
       $t->has_package("ntp");
       $t->has_package("unzip");
       $t->has_file("/etc/ntp.conf");
       $t->has_service_running("ntp");
       $t->has_content( "/etc/passwd", qr{root:x:0:}ms );
-
+    
       run "ls -l";
       $t->ok( $? == 0, "ls -l returns success." );
-
+    
       $t->finish;
     };
-
+    
     1;
     ```
 
@@ -62,22 +62,21 @@ With Rex/Boxes you can easily create your test environment with VirtualBox. You 
         ```perl
         # Rexfile
         set box => "KVM";
-
+        
         #
         # CALL:
         # rex init --name=gpw --url=http://domain.tld/ubuntu-server-12.10-amd64.qcow2
-        desc
-          "Initialize and start the VM: rex init --name=vmname [--url=http://...]";
+        desc "Initialize and start the VM: rex init --name=vmname [--url=http://...]";
         task "init", make {
           my $param = shift;
-
+        
           box {
             my ($box) = @_;
             $box->name( $param->{name} );
-
+        
             # where to download the base image
             $box->url( $param->{url} );
-
+        
             # default is nat
             $box->network(
               1 => {
@@ -88,19 +87,19 @@ With Rex/Boxes you can easily create your test environment with VirtualBox. You 
                 bridge => "br1",
               }
             );
-
+        
             # define the authentication to the box
             # if you're downloading one from box.rexify.org this is the default.
             $box->auth(
               user     => "root",
               password => "box",
             );
-
+        
             # if you want to provision the machine,
             # you can define the tasks to do that
             $box->setup(qw/install_webserver/);
           };
-
+        
         };
         ```
 
@@ -123,14 +122,14 @@ Changes in the Cloud API
             ```perl
             cloud_service "RackSpace";
             my $vol_id = cloud_volume create => { size => 1, };
-
+            
             my $instance = cloud_instance create => {
               image_id => "80fbcb55-b206-41f9-9bc2-2dd7aac6c061",
               name     => "myvm01",
               flavor   => "performance1-1",
               networks => ["a733f9d7-098e-4bf1-881d-5a91e84b44bb"]; # networks is optional
             };
-
+            
             cloud_volume
               attach => $vol_id,
               to     => $instance->{id};

--- a/content/docs/release_notes/0.46.md
+++ b/content/docs/release_notes/0.46.md
@@ -133,14 +133,14 @@ Changes in the Cloud API
 
             cloud_volume
               attach => $vol_id,
-              to     => $instance > {id};
+              to     => $instance->{id};
             ```
 
     -   Terminating an instance and removing the volume.
 
             ```perl
             cloud_service "RackSpace";
-            cloud_instance terminate => $instance > {id};
+            cloud_instance terminate => $instance->{id};
             cloud_volume delete      => $vol_id;
             ```
 

--- a/content/docs/release_notes/0.47.0.md
+++ b/content/docs/release_notes/0.47.0.md
@@ -20,33 +20,32 @@ With Rex::Test it is possible to test your Rexfile on a local VM before executin
         use Rex::Test::Base;
         use Data::Dumper;
         use Rex -base;
-
+        
         set box => "KVM";
-
+        
         test {
           my $t = shift;
-
+        
           $t->name("ubuntu test");
-
-          $t->base_vm(
-            "http://box.rexify.org/box/ubuntu-server-12.10-amd64.img");
+        
+          $t->base_vm("http://box.rexify.org/box/ubuntu-server-12.10-amd64.img");
           $t->vm_auth( user => "root", password => "box" );
-
+        
           $t->run_task("setup");
-
+        
           $t->has_package("vim");
           $t->has_package("ntp");
           $t->has_package("unzip");
           $t->has_file("/etc/ntp.conf");
           $t->has_service_running("ntp");
           $t->has_content( "/etc/passwd", qr{root:x:0:}ms );
-
+        
           run "ls -l";
           $t->ok( $? == 0, "ls -l returns success." );
-
+        
           $t->finish;
         };
-
+        
         1;
         ```
 
@@ -83,14 +82,12 @@ With Rex::Test it is possible to test your Rexfile on a local VM before executin
         ```perl
         task "prepare", sub {
           service "apache2",
-            ensure => "started",
-            start  => "/usr/local/bin/httpd -f /etc/my/httpd.conf",
-            stop   => "killall httpd",
-            status => "ps -efww | grep httpd",
-            restart =>
-            "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf",
-            reload =>
-            "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf";
+            ensure  => "started",
+            start   => "/usr/local/bin/httpd -f /etc/my/httpd.conf",
+            stop    => "killall httpd",
+            status  => "ps -efww | grep httpd",
+            restart => "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf",
+            reload  => "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf";
         };
         ```
 

--- a/content/docs/release_notes/0.51.2.md
+++ b/content/docs/release_notes/0.51.2.md
@@ -17,7 +17,7 @@ These are the changes in 0.51 release.
     -   cmdb/{hostname}.yml
     -   cmdb/default.yml
 
-     
+     
 
     For example, if you have a **CentOS** server with the hostname **web01**, this means that if you request the key **maxconn** Rex will first try to find the key inside **cmdb/CentOS/web01.yml** and if it doesn't find the Rex will try the next file in the lookup path.
 
@@ -28,7 +28,7 @@ These are the changes in 0.51 release.
         };
         ```
 
-     
+     
 
     If you're using [Rex::Ext::ParamLookup](http://modules.rexify.org/module/Rex::Ext::ParamLookup) it is even easier to work with a CMDB. You can write your code without using a CMDB and later, if you decide to use one, you can just add it without changing your code.
 
@@ -43,7 +43,7 @@ These are the changes in 0.51 release.
 
     This will first check if there is a task parameter named **maxconn** and if not, it will try to look inside the CMDB. If it doesn't find the key anywhere it will just return the default provided by the second parameter (in this example *4096*).
 
-     
+     
 
 -   **Store server groups in an ini file**
 
@@ -85,7 +85,7 @@ These are the changes in 0.51 release.
           service [@services] => "restart";
           };
 
-     
+     
         ```
 
 ## Bugfixes

--- a/content/docs/release_notes/0.51.2.md
+++ b/content/docs/release_notes/0.51.2.md
@@ -35,7 +35,7 @@ These are the changes in 0.51 release.
         ```perl
         use Rex -feature => ['0.51'];
         use Rex::Ext::ParamLookup;
-
+        
         task "setup", make {
           my $maxconn = param_lookup "maxconn", 4096;
         };
@@ -77,7 +77,7 @@ These are the changes in 0.51 release.
 
         ```perl
         use Rex -feature => ['0.51'];
-
+        
         task "restart_services",
           group => "redis",
           make {

--- a/content/docs/release_notes/0.52.1.md
+++ b/content/docs/release_notes/0.52.1.md
@@ -41,11 +41,11 @@ We welcome any feedback and if you want to help developing this webfrontend feel
 
         ```perl
         before_task_start mytask => sub {
-
+        
           # do some things
         };
         after_task_finished mytask => sub {
-
+        
           # do some things
         };
         ```

--- a/content/docs/release_notes/0.53.1.md
+++ b/content/docs/release_notes/0.53.1.md
@@ -39,9 +39,9 @@ A first version of the Rex::JobControl Webfrontend will also be released in the 
         resource "motd", sub {
           my ($params) = @_;
           my $name = resource_name;
-
+        
           if ( $params->{ensure} eq "present" ) {
-
+        
             # do some things.
             if ( !is_file($name) ) {
               file $name, content => $params->{content};
@@ -66,7 +66,7 @@ A first version of the Rex::JobControl Webfrontend will also be released in the 
             ensure    => present,
             content   => "Hello World.",
             on_change => sub {
-
+        
             # do something when changed event was triggered
             };
         };

--- a/content/docs/release_notes/0.54.3.md
+++ b/content/docs/release_notes/0.54.3.md
@@ -14,7 +14,7 @@ path\_map is a new feature developed by Erik Huelsmann to ease the management of
 
     ```perl
     use Rex -feature => ['0.54'];
-
+    
     set path_map => {
       "files/" => [
         "files/{environment}/{hostname}/", "files/{environment}/",
@@ -25,7 +25,7 @@ path\_map is a new feature developed by Erik Huelsmann to ease the management of
         "templates/{hostname}/",
       ],
     };
-
+    
     task "setup",
       group => "frontends",
       sub {
@@ -34,7 +34,7 @@ path\_map is a new feature developed by Erik Huelsmann to ease the management of
         owner  => "root",
         group  => "root",
         mode   => 644;
-
+    
       file "/etc/ntp.conf",
         content => template("templates/etc/ntp.conf"),
         owner   => "root",

--- a/content/docs/release_notes/0.8.md
+++ b/content/docs/release_notes/0.8.md
@@ -11,11 +11,11 @@ title: Release notes for 0.8
         ```perl
         task "change", sub {
           chown "jan", "/home/jan", recursive => 1;
-
+        
           chgrp "user", "/home/jan", recursive => 1;
-
+        
           chmod 644, "/etc/passwd";
-
+        
         };
         ```
 
@@ -27,7 +27,7 @@ title: Release notes for 0.8
         task "manip", sub {
           delete_lines_matching "/var/log/auth.log", matching => "root";
           delete_lines_matching "/var/log/auth.log", matching => qr{Failed};
-
+        
           append_if_no_such_line "/etc/groups",
             "mygroup:*:100:myuser1,myuser2", "mygroup";
           append_if_no_such_line "/etc/groups",
@@ -56,7 +56,7 @@ title: Release notes for 0.8
             from   => "table",
             where  => "enabled=1",
           };
-
+        
           db
             insert => "table",
             {
@@ -64,7 +64,7 @@ title: Release notes for 0.8
             field2 => "value2",
             field3 => 5,
             };
-
+        
           db
             update => "table",
             {
@@ -74,7 +74,7 @@ title: Release notes for 0.8
             },
             where => "id=5",
             };
-
+        
           db
             delete => "table",
             { where => "id < 5", };

--- a/content/docs/release_notes/0.9.md
+++ b/content/docs/release_notes/0.9.md
@@ -20,11 +20,11 @@ title: Release notes for 0.9
           on_rollback {
             unlink "/tmp/test";
           };
-
+        
           touch "/tmp/test";
           die;
         };
-
+        
         task "make", sub {
           transaction {
             do_task "do_something";
@@ -53,7 +53,7 @@ title: Release notes for 0.9
         task "upload", "server1", sub {
           file "$path/vhost.conf",
             content => template("../../templates/vhost.conf.tpl"),
-
+        
             # on change of the file, do something
             on_change => sub { say "file was modified"; };
         };

--- a/content/docs/release_notes/1.0.0.md
+++ b/content/docs/release_notes/1.0.0.md
@@ -35,7 +35,7 @@ To use this it is required to have *augtool* installed on your servers. This is 
 
     ```perl
     use Rex::Commands::Augeas;
-
+    
     task "prepare", sub {
       augeas
         insert    => "/files/etc/hosts",
@@ -43,7 +43,7 @@ To use this it is required to have *augtool* installed on your servers. This is 
         after     => "/7",
         ipaddr    => "192.168.2.23",
         canonical => "frontend01";
-
+    
       augeas modify =>
         "/files/etc/ssh/sshd_config/PermitRootLogin" => "without-password",
         on_change                                    => sub {
@@ -62,7 +62,7 @@ The PkgConf commands are especially usefull on debian/ubuntu systems to query an
 
     ```perl
     use Rex::Commands::PkgConf;
-
+    
     task "prepare", sub {
       set_pkgconf(
         "mysql-server-5.5",

--- a/content/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.md
+++ b/content/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.md
@@ -168,7 +168,7 @@ It is also possible to define the server or group to connect to.
     make {
       # run setup() task of Rex::OS::Base module
       Rex::OS::Base::setup();
-
+    
       # run setup() task of Rex::NTP::Base module
       Rex::NTP::Base::setup();
     };
@@ -204,6 +204,7 @@ Load the **Rex::Test::Base** framework and the Rex basic commands.
     test {
       my $t = shift;
       $t->name("ubuntu test");
+    
       # we will add more code here in a bit
     };
     1;
@@ -213,7 +214,7 @@ Create a new test named **ubuntu test**. For every test Rex will create a new vm
 
     ```perl
       $t->base_vm("http://box.rexify.org/box/ubuntu-server-12.10-amd64.ova");
-      $t->vm_auth(user => "root", password => "box");
+      $t->vm_auth( user => "root", password => "box" );
     ```
 
 Define the url where to download the base VM image and the authentication.
@@ -228,15 +229,15 @@ Define which task to run on the VM.
       $t->has_package("vim");
       $t->has_package("ntp");
       $t->has_package("unzip");
-
+      
       $t->has_file("/etc/ntp.conf");
-
+      
       $t->has_service_running("ntp");
-
-      $t->has_content("/etc/passwd", qr{root:x:0:}ms);
-
+      
+      $t->has_content( "/etc/passwd", qr{root:x:0:}ms );
+      
       run "ls -l";
-      $t->ok($? == 0, "ls -l returns success.");
+      $t->ok( $? == 0, "ls -l returns success." );
     ```
 
 Run the tests. You can also use normal rex functions here.

--- a/content/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.md
+++ b/content/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.md
@@ -55,14 +55,14 @@ You can define dependencies to Rex modules and to Perl modules.
     Author: jan gehring 
     License: Apache 2.0
     Require:
-      Rex::NTP::Base:
-        git: https://github.com/krimdomu/rex-ntp-base.git
-        branch: master
-      Rex::OS::Base:
-        git: https://github.com/krimdomu/rex-os-base.git
-        branch: master
+      Rex::NTP::Base:
+        git: https://github.com/krimdomu/rex-ntp-base.git
+        branch: master
+      Rex::OS::Base:
+        git: https://github.com/krimdomu/rex-os-base.git
+        branch: master
     PerlRequire:
-      - Moo
+      - Moo
 
 In this file you see that we define some dependencies to custom Rex modules located in git repositories. The `rexify --resolve-deps` command will read the **meta.yml** file and download all these dependencies into the **lib** directory.
 
@@ -100,15 +100,15 @@ Load all server groups from the file **server.ini**.
 
     ```perl
     set cmdb => {
-      type => "YAML",
-      path => [
-        "cmdb/{operatingsystem}/{hostname}.yml",
-        "cmdb/{operatingsystem}/default.yml",
-        "cmdb/{environment}/{hostname}.yml",
-        "cmdb/{environment}/default.yml",
-        "cmdb/{hostname}.yml",
-        "cmdb/default.yml",
-      ],
+      type => "YAML",
+      path => [
+        "cmdb/{operatingsystem}/{hostname}.yml",
+        "cmdb/{operatingsystem}/default.yml",
+        "cmdb/{environment}/{hostname}.yml",
+        "cmdb/{environment}/default.yml",
+        "cmdb/{hostname}.yml",
+        "cmdb/default.yml",
+      ],
     };
     ```
 
@@ -143,9 +143,9 @@ It is possible to use every Rex::Hardware variable inside the path.
 
     ```perl
     include qw/
-      Rex::OS::Base
-      Rex::NTP::Base
-      /;
+      Rex::OS::Base
+      Rex::NTP::Base
+      /;
     ```
 
 Include all needed Rex modules. With **include** all the tasks inside these modules won't get displayed with `rex -T`.
@@ -166,11 +166,11 @@ It is also possible to define the server or group to connect to.
 
     ```perl
     make {
-      # run setup() task of Rex::OS::Base module
-      Rex::OS::Base::setup();
+      # run setup() task of Rex::OS::Base module
+      Rex::OS::Base::setup();
 
-      # run setup() task of Rex::NTP::Base module
-      Rex::NTP::Base::setup();
+      # run setup() task of Rex::NTP::Base module
+      Rex::NTP::Base::setup();
     };
     ```
 
@@ -202,8 +202,8 @@ Load the **Rex::Test::Base** framework and the Rex basic commands.
 
     ```perl
     test {
-      my $t = shift;
-      $t->name("ubuntu test");
+      my $t = shift;
+      $t->name("ubuntu test");
       # we will add more code here in a bit
     };
     1;
@@ -225,18 +225,18 @@ Define the url where to download the base VM image and the authentication.
 Define which task to run on the VM.
 
     ```perl
-      $t->has_package("vim");
-      $t->has_package("ntp");
-      $t->has_package("unzip");
+      $t->has_package("vim");
+      $t->has_package("ntp");
+      $t->has_package("unzip");
 
-      $t->has_file("/etc/ntp.conf");
+      $t->has_file("/etc/ntp.conf");
 
-      $t->has_service_running("ntp");
+      $t->has_service_running("ntp");
 
-      $t->has_content("/etc/passwd", qr{root:x:0:}ms);
+      $t->has_content("/etc/passwd", qr{root:x:0:}ms);
 
-      run "ls -l";
-      $t->ok($? == 0, "ls -l returns success.");
+      run "ls -l";
+      $t->ok($? == 0, "ls -l returns success.");
     ```
 
 Run the tests. You can also use normal rex functions here.
@@ -244,7 +244,7 @@ Run the tests. You can also use normal rex functions here.
 At the end finish the tests with:
 
     ```perl
-      $t->finish;
+      $t->finish;
     ```
 
 You can now run the tests with `rex Test:run`.

--- a/content/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.md
+++ b/content/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.md
@@ -204,6 +204,9 @@ Load the **Rex::Test::Base** framework and the Rex basic commands.
     test {
       my $t = shift;
       $t->name("ubuntu test");
+      # we will add more code here in a bit
+    };
+    1;
     ```
 
 Create a new test named **ubuntu test**. For every test Rex will create a new vm.
@@ -242,8 +245,6 @@ At the end finish the tests with:
 
     ```perl
       $t->finish;
-    };
-    1;
     ```
 
 You can now run the tests with `rex Test:run`.

--- a/content/docs/rex_book/infrastructure/ssh_as_an_agent.md
+++ b/content/docs/rex_book/infrastructure/ssh_as_an_agent.md
@@ -38,7 +38,7 @@ If you have many servers you want to connect to, you ususally don't want to conn
     parallelism 15;
 
     task "prepare", group => "frontends", sub {
-       # do something
+       # do something
     };
     ```
 

--- a/content/docs/rex_book/infrastructure/ssh_as_an_agent.md
+++ b/content/docs/rex_book/infrastructure/ssh_as_an_agent.md
@@ -29,17 +29,19 @@ If you have many servers you want to connect to, you ususally don't want to conn
 
     ```perl
     use Rex -feature => ['1.0'];
-
+    
     user "root";
     password "foob4r";
-
+    
     group frontends => "frontend[01..50]";
-
+    
     parallelism 15;
-
-    task "prepare", group => "frontends", sub {
-       # do something
-    };
+    
+    task "prepare",
+      group => "frontends",
+      sub {
+      # do something
+      };
     ```
 
 This will connect to 15 servers in parallel and executes the task.

--- a/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
+++ b/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
@@ -86,21 +86,21 @@ In the Rexfile you'll find the task setup\_server.
     task "setup_server",
       group => "server",
       make {
-        # we will add more code here in a bit
-    };
+      # we will add more code here in a bit
+      };
     ```
 
 This task is configured to run on all servers registered in the group server.
 
     ```perl
     Rex::LDAP::OpenLDAP::setup {
-        ldap_admin_password         => 'admin',
-        ldap_base_dn                => 'dc=rexify,dc=org',
-        ldap_base_dn_admin_password => 'test',
-        ldap_configure_tls          => TRUE,
-      };
-
-      Rex::LDAP::OpenLDAP::UserManagement::Server::add_ssh_public_key;
+      ldap_admin_password         => 'admin',
+      ldap_base_dn                => 'dc=rexify,dc=org',
+      ldap_base_dn_admin_password => 'test',
+      ldap_configure_tls          => TRUE,
+    };
+    
+    Rex::LDAP::OpenLDAP::UserManagement::Server::add_ssh_public_key;
     ```
 
 First it install OpenLDAP and create a root database for you. It also configures the admin password of your LDAP server.
@@ -122,12 +122,12 @@ First we need to create a default folder structure inside it, so you can manage 
       ensure      => 'present',
       objectClass => [ 'top', 'organizationalUnit' ],
       ou          => 'People';
-
+    
     ldap_entry "ou=Groups,dc=rexify,dc=org",
       ensure      => 'present',
       objectClass => [ 'top', 'organizationalUnit' ],
       ou          => 'Groups';
-
+    
     ldap_entry "ou=Services,dc=rexify,dc=org",
       ensure      => 'present',
       objectClass => [ 'top', 'organizationalUnit' ],
@@ -160,7 +160,7 @@ Now lets create a sample group and user.
       ensure    => 'present',
       dn        => 'ou=Groups,dc=rexify,dc=org',
       gidNumber => 3000;
-
+    
     ldap_account "sampleuser",
       ensure        => 'present',
       dn            => 'ou=People,dc=rexify,dc=org',
@@ -173,7 +173,7 @@ Now lets create a sample group and user.
       mail          => 'sample.user@gmail.com',
       userPassword  => '{CRYPT}vPYgtKD.j9iL2',
       sshPublicKey  => 'ssh-rsa AAAAB3NzaC1y...',
-      groups => ['cn=ldapusers,ou=Groups,dc=rexify,dc=org'];
+      groups        => ['cn=ldapusers,ou=Groups,dc=rexify,dc=org'];
     ```
 
 This will create a group names ldapusers inside the organizational unit (ou) ou=Groups,dc=rexify,dc=org and a user sampleuser inside ou=People,dc=rexify,dc=org. You can create the crypted password string with the tool slapdpasswd.  
@@ -185,8 +185,8 @@ Now, after you have setup OpenLDAP it is time to setup SSSD. For this there is a
     task "setup_client",
       group => "client",
       make {
-        # we will add more code here in a bit
-    };
+      # we will add more code here in a bit
+      };
     ```
 
 This task is configured to run on all servers inside the group client.

--- a/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
+++ b/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
@@ -86,6 +86,8 @@ In the Rexfile you'll find the task setup\_server.
     task "setup_server",
       group => "server",
       make {
+        # we will add more code here in a bit
+    };
     ```
 
 This task is configured to run on all servers registered in the group server.
@@ -183,6 +185,8 @@ Now, after you have setup OpenLDAP it is time to setup SSSD. For this there is a
     task "setup_client",
       group => "client",
       make {
+        # we will add more code here in a bit
+    };
     ```
 
 This task is configured to run on all servers inside the group client.

--- a/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
+++ b/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
@@ -84,8 +84,8 @@ In the Rexfile you'll find the task setup\_server.
 
     ```perl
     task "setup_server",
-      group => "server",
-      make {
+      group => "server",
+      make {
         # we will add more code here in a bit
     };
     ```
@@ -94,13 +94,13 @@ This task is configured to run on all servers registered in the group server.
 
     ```perl
     Rex::LDAP::OpenLDAP::setup {
-        ldap_admin_password         => 'admin',
-        ldap_base_dn                => 'dc=rexify,dc=org',
-        ldap_base_dn_admin_password => 'test',
-        ldap_configure_tls          => TRUE,
-      };
+        ldap_admin_password         => 'admin',
+        ldap_base_dn                => 'dc=rexify,dc=org',
+        ldap_base_dn_admin_password => 'test',
+        ldap_configure_tls          => TRUE,
+      };
 
-      Rex::LDAP::OpenLDAP::UserManagement::Server::add_ssh_public_key;
+      Rex::LDAP::OpenLDAP::UserManagement::Server::add_ssh_public_key;
     ```
 
 First it install OpenLDAP and create a root database for you. It also configures the admin password of your LDAP server.
@@ -119,19 +119,19 @@ First we need to create a default folder structure inside it, so you can manage 
 
     ```perl
     ldap_entry "ou=People,dc=rexify,dc=org",
-      ensure      => 'present',
-      objectClass => [ 'top', 'organizationalUnit' ],
-      ou          => 'People';
+      ensure      => 'present',
+      objectClass => [ 'top', 'organizationalUnit' ],
+      ou          => 'People';
 
     ldap_entry "ou=Groups,dc=rexify,dc=org",
-      ensure      => 'present',
-      objectClass => [ 'top', 'organizationalUnit' ],
-      ou          => 'Groups';
+      ensure      => 'present',
+      objectClass => [ 'top', 'organizationalUnit' ],
+      ou          => 'Groups';
 
     ldap_entry "ou=Services,dc=rexify,dc=org",
-      ensure      => 'present',
-      objectClass => [ 'top', 'organizationalUnit' ],
-      ou          => 'Services';
+      ensure      => 'present',
+      objectClass => [ 'top', 'organizationalUnit' ],
+      ou          => 'Services';
     ```
 
 This code creates 3 *folders* (the LDAP name for such a *folder* is *organizationalUnit*, hence the acronym ou). One for the user accounts *ou=People,dc=rexify,dc=org*, one for the groups *ou=Groups,dc=rexify,dc=org* and one for special service accounts *ou=Services,dc=rexify,dc=org*.
@@ -142,38 +142,38 @@ Then you need to create a service user for sssd. SSSD use this user to search th
 
     ```perl
     ldap_account "sssd",
-      ensure        => 'present',
-      dn            => 'ou=Services,dc=rexify,dc=org',
-      givenName     => 'SSSD',
-      sn            => 'Service User',
-      uidNumber     => '4000',
-      gidNumber     => 0,
-      loginShell    => '/bin/false',
-      homeDirectory => '/tmp',
-      userPassword  => 'abcdef';
+      ensure        => 'present',
+      dn            => 'ou=Services,dc=rexify,dc=org',
+      givenName     => 'SSSD',
+      sn            => 'Service User',
+      uidNumber     => '4000',
+      gidNumber     => 0,
+      loginShell    => '/bin/false',
+      homeDirectory => '/tmp',
+      userPassword  => 'abcdef';
     ```
 
 Now lets create a sample group and user.
 
     ```perl
     ldap_group "ldapusers",
-      ensure    => 'present',
-      dn        => 'ou=Groups,dc=rexify,dc=org',
-      gidNumber => 3000;
+      ensure    => 'present',
+      dn        => 'ou=Groups,dc=rexify,dc=org',
+      gidNumber => 3000;
 
     ldap_account "sampleuser",
-      ensure        => 'present',
-      dn            => 'ou=People,dc=rexify,dc=org',
-      givenName     => 'SampleUser',
-      sn            => 'Surename',
-      uidNumber     => 5000,
-      gidNumber     => 3000,
-      homeDirectory => '/home/sampleuser',
-      loginShell    => '/bin/bash',
-      mail          => 'sample.user@gmail.com',
-      userPassword  => '{CRYPT}vPYgtKD.j9iL2',
-      sshPublicKey  => 'ssh-rsa AAAAB3NzaC1y...',
-      groups => ['cn=ldapusers,ou=Groups,dc=rexify,dc=org'];
+      ensure        => 'present',
+      dn            => 'ou=People,dc=rexify,dc=org',
+      givenName     => 'SampleUser',
+      sn            => 'Surename',
+      uidNumber     => 5000,
+      gidNumber     => 3000,
+      homeDirectory => '/home/sampleuser',
+      loginShell    => '/bin/bash',
+      mail          => 'sample.user@gmail.com',
+      userPassword  => '{CRYPT}vPYgtKD.j9iL2',
+      sshPublicKey  => 'ssh-rsa AAAAB3NzaC1y...',
+      groups => ['cn=ldapusers,ou=Groups,dc=rexify,dc=org'];
     ```
 
 This will create a group names ldapusers inside the organizational unit (ou) ou=Groups,dc=rexify,dc=org and a user sampleuser inside ou=People,dc=rexify,dc=org. You can create the crypted password string with the tool slapdpasswd.  
@@ -183,8 +183,8 @@ Now, after you have setup OpenLDAP it is time to setup SSSD. For this there is a
 
     ```perl
     task "setup_client",
-      group => "client",
-      make {
+      group => "client",
+      make {
         # we will add more code here in a bit
     };
     ```
@@ -193,13 +193,13 @@ This task is configured to run on all servers inside the group client.
 
     ```perl
     Rex::LDAP::OpenLDAP::UserManagement::Client::setup {
-      ldap_base_dn       => 'dc=rexify,dc=org',
-      ldap_uri           => 'ldaps://10.211.55.168',
-      ldap_bind_dn       => 'cn=sssd,ou=Services,dc=rexify,dc=org',
-      ldap_bind_password => 'abcdef',
-      ldap_base_user_dn  => 'ou=People,dc=rexify,dc=org',
-      ldap_base_group_dn => 'ou=Groups,dc=rexify,dc=org',
-      configure_ssh_ldap => TRUE,
+      ldap_base_dn       => 'dc=rexify,dc=org',
+      ldap_uri           => 'ldaps://10.211.55.168',
+      ldap_bind_dn       => 'cn=sssd,ou=Services,dc=rexify,dc=org',
+      ldap_bind_password => 'abcdef',
+      ldap_base_user_dn  => 'ou=People,dc=rexify,dc=org',
+      ldap_base_group_dn => 'ou=Groups,dc=rexify,dc=org',
+      configure_ssh_ldap => TRUE,
     };
     ```
 
@@ -223,5 +223,5 @@ The configuration of this script can be done in the file /etc/ssh/pubkey.yaml. T
     base_dn: 'dc=rexify,dc=org'
     filter: (&(uid={{LOGIN_NAME}})(objectClass=posixAccount))
     #tls:
-    #        verify: optional
-    #        cafile: /etc/openldap/certs/cacert.pem
+    #        verify: optional
+    #        cafile: /etc/openldap/certs/cacert.pem

--- a/content/docs/rex_book/the_rex_dsl/grouping_servers.md
+++ b/content/docs/rex_book/the_rex_dsl/grouping_servers.md
@@ -6,14 +6,14 @@ Rex offers you a powerfull way to group your servers. The simplest way to use gr
 
     ```perl
     group frontends => "frontend01", "frontend02", "frontend03";
-    group backends => "backend01", "backend02";
+    group backends  => "backend01",  "backend02";
     ```
 
 Rex offers also a simple notation to define server ranges, so that you don't need to type so much.
 
     ```perl
     group frontends => "frontend[01..03]";
-    group backends => "backend[01..02]";
+    group backends  => "backend[01..02]";
     ```
 
 This notation will just expand to frontend01, frontend02 and frontend03 for the frontends group and to backend01 and backend02 for the backends group.
@@ -21,10 +21,9 @@ This notation will just expand to frontend01, frontend02 and frontend03 for the 
 Custom parameters for servers are possible with a slightly enhanced syntax since version 0.47:
 
     ```perl
-    group frontends =>
-       "frontend01" => { user => "bob" },
-       "frontend02" => { user => "alice" },
-       "frontend03";
+    group frontends => "frontend01" => { user => "bob" },
+      "frontend02"  => { user       => "alice" },
+      "frontend03";
     ```
 
 Because the Rexfile is a Perl script you can just use more advanced things like querying a database, ldap or your dns.
@@ -32,17 +31,21 @@ Because the Rexfile is a Perl script you can just use more advanced things like 
 To add your groups to the tasks you have to use the group option within the task generation.
 
     ```perl
-    task "mytask", group => "mygroup", sub {
-       # do something
-    };
+    task "mytask",
+      group => "mygroup",
+      sub {
+      # do something
+      };
     ```
 
 If you need to define multiple groups for a task, you can just use an array.
 
     ```perl
-    task "mytask", group => ["mygroup", "mygroup2"], sub {
-       # do something
-    };
+    task "mytask",
+      group => [ "mygroup", "mygroup2" ],
+      sub {
+      # do something
+      };
     ```
 
 ## Using an INI file to define server groups
@@ -52,7 +55,7 @@ Rex offers a simple way to query ini files for group creation. To use ini files 
     ```perl
     use Rex -feature => ['1.0'];
     use Rex::Group::Lookup::INI;
-
+    
     groups_file "/path/to/your/file.ini";
     ```
 
@@ -85,12 +88,14 @@ Rex also offers a little bit advanced functions for the ini file. You can define
 These additional options (in this example maintenance can be queried with the option method from the connection object.
 
     ```perl
-    task "prepare", group => "frontends", sub {
-       if(connection->server->option("maintenance")) {
-          say "This server is in maintenance mode, so i'm going to stop all services";
-          service ["apache2", "postfix"] => "stop";
-       }
-    };
+    task "prepare",
+      group => "frontends",
+      sub {
+      if ( connection->server->option("maintenance") ) {
+        say "This server is in maintenance mode, so i'm going to stop all services";
+        service [ "apache2", "postfix" ] => "stop";
+      }
+      };
     ```
 
 ## Quering a database to define server groups
@@ -100,27 +105,25 @@ If you want to get your server groups right out of an existing database you can 
     ```perl
     use Rex -feature => ['1.0'];
     use DBI;
-
+    
     my $username = "dbuser";
     my $password = "dbpassword";
     my $database = "hostdb";
     my $hostname = "mysql.intern.lan";
     my $port     = 3306;
     my $dsn      = "DBI:mysql:database=$database;host=$hostname;port=$port";
-    my $dbh      = DBI->connect($username, $password);
-
-    my $sth      = $dbh->prepare("SELECT * FROM hostlist WHERE enabled=1");
-
+    my $dbh      = DBI->connect( $username, $password );
+    
+    my $sth = $dbh->prepare("SELECT * FROM hostlist WHERE enabled=1");
+    
     my %server_group = ();
-    while(my $row = $sth->fetchrow_hashref) {
-       my $group_name  = $row->{server_group};
-       my $server_name = $row->{server_name};
-       push @{ $server_group{ $group_name } }, $server_name;
+    while ( my $row = $sth->fetchrow_hashref ) {
+      my $group_name  = $row->{server_group};
+      my $server_name = $row->{server_name};
+      push @{ $server_group{$group_name} }, $server_name;
     }
-
-    map {
-       group $_ => @{ $server_group{$_} };
-    } keys %server_group;
+    
+    map { group $_ => @{ $server_group{$_} }; } keys %server_group;
     ```
 
 This example expects the following column names:
@@ -133,7 +136,7 @@ This example expects the following column names:
 If there is no built-in function that fits your needs for group creation, you can do it all by yourself. Because the Rexfile is just a plain perl script and the group command is just a perl function that expects the group name as first parameter, and uses all other parameters for the servers, you can create your own function.
 
     ```perl
-    my @list = ("some", "list", "entries");
-    group mygroup => grep { /list/ } @list;
-    group myserver => map {"s$_.domain.com"} qw(1 3 7);
+    my @list = ( "some", "list", "entries" );
+    group mygroup  => grep { /list/ } @list;
+    group myserver => map  { "s$_.domain.com" } qw(1 3 7);
     ```

--- a/content/docs/rex_book/the_rex_dsl/grouping_servers.md
+++ b/content/docs/rex_book/the_rex_dsl/grouping_servers.md
@@ -22,9 +22,9 @@ Custom parameters for servers are possible with a slightly enhanced syntax since
 
     ```perl
     group frontends =>
-       "frontend01" => { user => "bob" },
-       "frontend02" => { user => "alice" },
-       "frontend03";
+       "frontend01" => { user => "bob" },
+       "frontend02" => { user => "alice" },
+       "frontend03";
     ```
 
 Because the Rexfile is a Perl script you can just use more advanced things like querying a database, ldap or your dns.
@@ -33,7 +33,7 @@ To add your groups to the tasks you have to use the group option within the task
 
     ```perl
     task "mytask", group => "mygroup", sub {
-       # do something
+       # do something
     };
     ```
 
@@ -41,7 +41,7 @@ If you need to define multiple groups for a task, you can just use an array.
 
     ```perl
     task "mytask", group => ["mygroup", "mygroup2"], sub {
-       # do something
+       # do something
     };
     ```
 
@@ -86,10 +86,10 @@ These additional options (in this example maintenance can be queried with the op
 
     ```perl
     task "prepare", group => "frontends", sub {
-       if(connection->server->option("maintenance")) {
-          say "This server is in maintenance mode, so i'm going to stop all services";
-          service ["apache2", "postfix"] => "stop";
-       }
+       if(connection->server->option("maintenance")) {
+          say "This server is in maintenance mode, so i'm going to stop all services";
+          service ["apache2", "postfix"] => "stop";
+       }
     };
     ```
 
@@ -105,21 +105,21 @@ If you want to get your server groups right out of an existing database you can 
     my $password = "dbpassword";
     my $database = "hostdb";
     my $hostname = "mysql.intern.lan";
-    my $port     = 3306;
-    my $dsn      = "DBI:mysql:database=$database;host=$hostname;port=$port";
-    my $dbh      = DBI->connect($username, $password);
+    my $port     = 3306;
+    my $dsn      = "DBI:mysql:database=$database;host=$hostname;port=$port";
+    my $dbh      = DBI->connect($username, $password);
 
-    my $sth      = $dbh->prepare("SELECT * FROM hostlist WHERE enabled=1");
+    my $sth      = $dbh->prepare("SELECT * FROM hostlist WHERE enabled=1");
 
     my %server_group = ();
     while(my $row = $sth->fetchrow_hashref) {
-       my $group_name  = $row->{server_group};
-       my $server_name = $row->{server_name};
-       push @{ $server_group{ $group_name } }, $server_name;
+       my $group_name  = $row->{server_group};
+       my $server_name = $row->{server_name};
+       push @{ $server_group{ $group_name } }, $server_name;
     }
 
     map {
-       group $_ => @{ $server_group{$_} };
+       group $_ => @{ $server_group{$_} };
     } keys %server_group;
     ```
 

--- a/content/docs/rex_book/the_rex_dsl/using_environments.md
+++ b/content/docs/rex_book/the_rex_dsl/using_environments.md
@@ -19,36 +19,36 @@ Creating environments is as easy as creating groups. To create environments you 
     use Rex -feature => ['1.0'];
 
     environment test => sub {
-      user "root";
-      password "b0x";
+      user "root";
+      password "b0x";
 
-      group frontend   => "fe01.test";
-      group middleware => "mw01.test";
-      group dbwrite    => "dbm01.test";
+      group frontend   => "fe01.test";
+      group middleware => "mw01.test";
+      group dbwrite    => "dbm01.test";
     };
 
     environment stage => sub {
-      user "root";
-      password "b0xst4g3";
+      user "root";
+      password "b0xst4g3";
 
-      group loadbalancer => "lb01.stage";
-      group frontend     => "fe01.stage";
-      group middleware   => "mw01.stage";
-      group dbread       => "dbs01.stage";
-      group dbwrite      => "dbm01.stage";
+      group loadbalancer => "lb01.stage";
+      group frontend     => "fe01.stage";
+      group middleware   => "mw01.stage";
+      group dbread       => "dbs01.stage";
+      group dbwrite      => "dbm01.stage";
     };
 
     environment live => sub {
-      user "admin";
-      password "b0xl1v3";
-      sudo_password "b0xl1v3";
-      sudo TRUE;
+      user "admin";
+      password "b0xl1v3";
+      sudo_password "b0xl1v3";
+      sudo TRUE;
 
-      group loadbalancer => "lb[01..02].live";
-      group frontend     => "fe[01..03].live";
-      group middleware   => "mw[01..02].live";
-      group dbread       => "dbs[01..02].live";
-      group dbwrite      => "dbm01.live";
+      group loadbalancer => "lb[01..02].live";
+      group frontend     => "fe[01..03].live";
+      group middleware   => "mw[01..02].live";
+      group dbread       => "dbs[01..02].live";
+      group dbwrite      => "dbm01.live";
     };
     ```
 
@@ -63,20 +63,20 @@ If you need to configure systems depending on the environment you can get the cu
     ```perl
     # Rexfile
     task "prepare", group => "frontend", make {
-      # configure ntp.conf depending on the environment
-      my $ntp_server = case environment, {
-                         test    => ["ntp01.test"],
-                         stage   => ["ntp01.stage"],
-                         live    => ["ntp01.live", "ntp02.live"],
-                         default => ["ntp01.test"],
-                       };
+      # configure ntp.conf depending on the environment
+      my $ntp_server = case environment, {
+                         test    => ["ntp01.test"],
+                         stage   => ["ntp01.stage"],
+                         live    => ["ntp01.live", "ntp02.live"],
+                         default => ["ntp01.test"],
+                       };
 
-      file "/etc/ntp.conf",
-        content   => template("templates/etc/ntp.conf", ntp_server => $ntp_server),
-        owner     => "root",
-        group     => "root",
-        mode      => 644,
-        on_change => make { service ntpd => "restart"; };
+      file "/etc/ntp.conf",
+        content   => template("templates/etc/ntp.conf", ntp_server => $ntp_server),
+        owner     => "root",
+        group     => "root",
+        mode      => 644,
+        on_change => make { service ntpd => "restart"; };
     };
     ```
 
@@ -95,20 +95,20 @@ The lookup path for the default YAML CMDB is as follow:
 
     # File: cmdb/default.yml
     ntp_server:
-      - ntp01.test
+      - ntp01.test
 
     # File: cmdb/test/default.yml
     ntp_server:
-      - ntp01.test
+      - ntp01.test
 
     # File: cmdb/stage/default.yml
     ntp_server:
-      - ntp01.stage
+      - ntp01.stage
 
     # File: cmdb/live/default.yml
     ntp_server:
-      - ntp01.live
-      - ntp02.live
+      - ntp01.live
+      - ntp02.live
 
 ### The Rexfile
 
@@ -120,20 +120,20 @@ To use the CMDB you have to require and configure the Rex::CMDB module first.
     use Rex::CMDB;
 
     set cmdb => {
-      type => "YAML",
-      path => "./cmdb",
+      type => "YAML",
+      path => "./cmdb",
     };
 
     task "prepare", group => "frontend", make {
-      # configure ntp.conf depending on the environment
-      my $ntp_server = get cmdb "ntp_server";
+      # configure ntp.conf depending on the environment
+      my $ntp_server = get cmdb "ntp_server";
 
-      file "/etc/ntp.conf",
-        content   => template("templates/etc/ntp.conf", ntp_server => $ntp_server),
-        owner     => "root",
-        group     => "root",
-        mode      => 644,
-        on_change => make { service ntpd => "restart"; };
+      file "/etc/ntp.conf",
+        content   => template("templates/etc/ntp.conf", ntp_server => $ntp_server),
+        owner     => "root",
+        group     => "root",
+        mode      => 644,
+        on_change => make { service ntpd => "restart"; };
     };
     ```
 

--- a/content/docs/rex_book/the_rex_dsl/using_environments.md
+++ b/content/docs/rex_book/the_rex_dsl/using_environments.md
@@ -17,33 +17,33 @@ Creating environments is as easy as creating groups. To create environments you 
     ```perl
     # Rexfile
     use Rex -feature => ['1.0'];
-
+    
     environment test => sub {
       user "root";
       password "b0x";
-
+    
       group frontend   => "fe01.test";
       group middleware => "mw01.test";
       group dbwrite    => "dbm01.test";
     };
-
+    
     environment stage => sub {
       user "root";
       password "b0xst4g3";
-
+    
       group loadbalancer => "lb01.stage";
       group frontend     => "fe01.stage";
       group middleware   => "mw01.stage";
       group dbread       => "dbs01.stage";
       group dbwrite      => "dbm01.stage";
     };
-
+    
     environment live => sub {
       user "admin";
       password "b0xl1v3";
       sudo_password "b0xl1v3";
       sudo TRUE;
-
+    
       group loadbalancer => "lb[01..02].live";
       group frontend     => "fe[01..03].live";
       group middleware   => "mw[01..02].live";
@@ -62,22 +62,24 @@ If you need to configure systems depending on the environment you can get the cu
 
     ```perl
     # Rexfile
-    task "prepare", group => "frontend", make {
+    task "prepare",
+      group => "frontend",
+      make {
       # configure ntp.conf depending on the environment
       my $ntp_server = case environment, {
-                         test    => ["ntp01.test"],
-                         stage   => ["ntp01.stage"],
-                         live    => ["ntp01.live", "ntp02.live"],
-                         default => ["ntp01.test"],
-                       };
-
+        test      => ["ntp01.test"],
+          stage   => ["ntp01.stage"],
+          live    => [ "ntp01.live", "ntp02.live" ],
+          default => ["ntp01.test"],
+      };
+    
       file "/etc/ntp.conf",
-        content   => template("templates/etc/ntp.conf", ntp_server => $ntp_server),
-        owner     => "root",
-        group     => "root",
-        mode      => 644,
+        content => template( "templates/etc/ntp.conf", ntp_server => $ntp_server ),
+        owner   => "root",
+        group   => "root",
+        mode    => 644,
         on_change => make { service ntpd => "restart"; };
-    };
+      };
     ```
 
 ## Environments and the CMDB
@@ -118,23 +120,25 @@ To use the CMDB you have to require and configure the Rex::CMDB module first.
     # Rexfile
     use Rex -feature => ['1.0'];
     use Rex::CMDB;
-
+    
     set cmdb => {
       type => "YAML",
       path => "./cmdb",
     };
-
-    task "prepare", group => "frontend", make {
+    
+    task "prepare",
+      group => "frontend",
+      make {
       # configure ntp.conf depending on the environment
       my $ntp_server = get cmdb "ntp_server";
-
+    
       file "/etc/ntp.conf",
-        content   => template("templates/etc/ntp.conf", ntp_server => $ntp_server),
-        owner     => "root",
-        group     => "root",
-        mode      => 644,
+        content => template( "templates/etc/ntp.conf", ntp_server => $ntp_server ),
+        owner   => "root",
+        group   => "root",
+        mode    => 644,
         on_change => make { service ntpd => "restart"; };
-    };
+      };
     ```
 
 Now you can run the task with `rex -E test prepare`.

--- a/content/docs/rex_book/the_rex_dsl/using_templates.md
+++ b/content/docs/rex_book/the_rex_dsl/using_templates.md
@@ -20,22 +20,22 @@ First you have to create it
     $ vim files/my.cnf.tpl
 
     [mysqld]
-    datadir                 = /var/lib/mysql
-    socket                  = /var/run/mysqld/mysqld.sock
-    user                    = mysql
+    datadir                 = /var/lib/mysql
+    socket                  = /var/run/mysqld/mysqld.sock
+    user                    = mysql
     # Disabling symbolic-links is recommended to prevent assorted security risks
-    symbolic-links          = 0
-    datadir                 = /var/lib/mysql
-    tmpdir                  = /tmp
+    symbolic-links          = 0
+    datadir                 = /var/lib/mysql
+    tmpdir                  = /tmp
     skip-external-locking
-    max_allowed_packet      = 64M
-    thread_stack            = 192K
-    max_connections         = <%= exists $conf->{"max_connections"} ? $conf->{"max_connections"} : "1000" %>
+    max_allowed_packet      = 64M
+    thread_stack            = 192K
+    max_connections         = <%= exists $conf->{"max_connections"} ? $conf->{"max_connections"} : "1000" %>
 
-    max_connect_errors      = 1000
-    table_cache             = <%= exists $conf->{"table_cache"} ? $conf->{"table_cache"} : "5000" %>
-    table_open_cache        = <%= exists $conf->{"table_open_cache"} ? $conf->{"table_open_cache"} : "5000" %>
-    thread_concurrency      = 10
+    max_connect_errors      = 1000
+    table_cache             = <%= exists $conf->{"table_cache"} ? $conf->{"table_cache"} : "5000" %>
+    table_open_cache        = <%= exists $conf->{"table_open_cache"} ? $conf->{"table_open_cache"} : "5000" %>
+    thread_concurrency      = 10
 
     #
     # ... and more ...
@@ -52,14 +52,14 @@ Than you can reference on it from within your Rexfile.
     group databases=> "mydb01", "mydb02";
 
     task "prepare_databases", group => "databases", sub {
-       file "/etc/my.cnf",
-          owner   => "root",
-          group   => "root",
-          mode    => "644",
-          content => template("files/my.cnf.tpl", conf => {
-                                 max_connections => "500",
-                                 table_cache     => "2500",
-                              });
+       file "/etc/my.cnf",
+          owner   => "root",
+          group   => "root",
+          mode    => "644",
+          content => template("files/my.cnf.tpl", conf => {
+                                 max_connections => "500",
+                                 table_cache     => "2500",
+                              });
     };
     ```
 
@@ -73,16 +73,16 @@ When you want to deliver a rexfile that includes the templates, you can use inli
     use Rex -feature => ['1.0'];
 
     task tempfiles => sub {
-        file '/tmp/test.txt' =>
-            content => template(
-                '@test',
-                test => {
-                    author => 'reneeb',
-                    target => 'rex',
-                },
-            ),
-            chmod => 644,
-        ;
+        file '/tmp/test.txt' =>
+            content => template(
+                '@test',
+                test => {
+                    author => 'reneeb',
+                    target => 'rex',
+                },
+            ),
+            chmod => 644,
+        ;
     };
 
     __DATA__
@@ -101,27 +101,27 @@ Rex knows that it has to look up the template in the `__DATA__` section of the f
     ```perl
     use Rex -feature => ['1.0'];
     task tempfiles => sub {
-        file '/tmp/test.txt' =>
-            content => template(
-                '@test',
-                test => {
-                    author => 'reneeb',
-                    target => 'rex',
-                },
-            ),
-            chmod => 644,
-        ;
+        file '/tmp/test.txt' =>
+            content => template(
+                '@test',
+                test => {
+                    author => 'reneeb',
+                    target => 'rex',
+                },
+            ),
+            chmod => 644,
+        ;
 
-        file '/tmp/rex.txt' =>
-            content => template(
-                '@rex',
-                test => {
-                    author => 'krimdomu',
-                    target => 'rex',
-                },
-            ),
-            chmod => 644,
-        ;
+        file '/tmp/rex.txt' =>
+            content => template(
+                '@rex',
+                test => {
+                    author => 'krimdomu',
+                    target => 'rex',
+                },
+            ),
+            chmod => 644,
+        ;
     };
 
     __DATA__

--- a/content/docs/rex_book/the_rex_dsl/using_templates.md
+++ b/content/docs/rex_book/the_rex_dsl/using_templates.md
@@ -113,7 +113,7 @@ Rex knows that it has to look up the template in the `__DATA__` section of the f
         ;
 
         file '/tmp/rex.txt' =>
-            content => template(>
+            content => template(
                 '@rex',
                 test => {
                     author => 'krimdomu',

--- a/content/docs/rex_book/the_rex_dsl/using_templates.md
+++ b/content/docs/rex_book/the_rex_dsl/using_templates.md
@@ -45,22 +45,27 @@ Than you can reference on it from within your Rexfile.
 
     ```perl
     use Rex -feature => ['1.0'];
-
+    
     user "root";
     key_auth;
-
-    group databases=> "mydb01", "mydb02";
-
-    task "prepare_databases", group => "databases", sub {
-       file "/etc/my.cnf",
-          owner   => "root",
-          group   => "root",
-          mode    => "644",
-          content => template("files/my.cnf.tpl", conf => {
-                                 max_connections => "500",
-                                 table_cache     => "2500",
-                              });
-    };
+    
+    group databases => "mydb01", "mydb02";
+    
+    task "prepare_databases",
+      group => "databases",
+      sub {
+      file "/etc/my.cnf",
+        owner   => "root",
+        group   => "root",
+        mode    => "644",
+        content => template(
+        "files/my.cnf.tpl",
+        conf => {
+          max_connections => "500",
+          table_cache     => "2500",
+        }
+        );
+      };
     ```
 
 ## Inline Templates
@@ -71,20 +76,19 @@ When you want to deliver a rexfile that includes the templates, you can use inli
 
     ```perl
     use Rex -feature => ['1.0'];
-
+    
     task tempfiles => sub {
-        file '/tmp/test.txt' =>
-            content => template(
-                '@test',
-                test => {
-                    author => 'reneeb',
-                    target => 'rex',
-                },
-            ),
-            chmod => 644,
+      file '/tmp/test.txt' => content => template(
+        '@test',
+        test => {
+          author => 'reneeb',
+          target => 'rex',
+        },
+        ),
+        chmod => 644,
         ;
     };
-
+    
     __DATA__
     @test
     This is a test written by <%= $test->{author} %>
@@ -100,36 +104,34 @@ Rex knows that it has to look up the template in the `__DATA__` section of the f
 
     ```perl
     use Rex -feature => ['1.0'];
-    task tempfiles => sub {
-        file '/tmp/test.txt' =>
-            content => template(
-                '@test',
-                test => {
-                    author => 'reneeb',
-                    target => 'rex',
-                },
-            ),
-            chmod => 644,
+    task tempfiles   => sub {
+      file '/tmp/test.txt' => content => template(
+        '@test',
+        test => {
+          author => 'reneeb',
+          target => 'rex',
+        },
+        ),
+        chmod => 644,
         ;
-
-        file '/tmp/rex.txt' =>
-            content => template(
-                '@rex',
-                test => {
-                    author => 'krimdomu',
-                    target => 'rex',
-                },
-            ),
-            chmod => 644,
+    
+      file '/tmp/rex.txt' => content => template(
+        '@rex',
+        test => {
+          author => 'krimdomu',
+          target => 'rex',
+        },
+        ),
+        chmod => 644,
         ;
     };
-
+    
     __DATA__
     @test
     This is a test written by <%= $test->{author} %>
     for a project called <%= $test->{target} %>
     @end
-
+    
     @rex
     Contribution by <%= $test->{author} %>
     for a project called <%= $test->{target} %>

--- a/content/docs/rex_book/working_with_files_and_packages/installing_packages.md
+++ b/content/docs/rex_book/working_with_files_and_packages/installing_packages.md
@@ -6,44 +6,47 @@ Installing packages is easy. You can use the pkg function for this.
 
     ```perl
     use Rex -feature => ['1.0'];
-
+    
     user "root";
     password "f00b4r";
-
-    task "prepare_system", group => "frontends", sub {
-       pkg "apache2",
-         ensure => "present";
-    };
+    
+    task "prepare_system",
+      group => "frontends",
+      sub {
+      pkg "apache2", ensure => "present";
+      };
     ```
 
 If you have to install multiple packages you can use an array so that you don't have to write that much.
 
     ```perl
     use Rex -feature => ['1.0'];
-
+    
     user "root";
     password "f00b4r";
-
-    task "prepare_system", group => "frontends", sub {
-       pkg ["apache2", "libphp5-apache2", "mysql-server"],
-         ensure => "present";
-    };
+    
+    task "prepare_system",
+      group => "frontends",
+      sub {
+      pkg [ "apache2", "libphp5-apache2", "mysql-server" ], ensure => "present";
+      };
     ```
 
 If you need to write a distribution independent module you can also use the case statement.
 
     ```perl
     user Rex -base;
-
+    
     user "root";
     password "f00b4r";
-
-    task "prepare_system", group => "frontends", sub {
-       my $packages = case operating_system,
-          Debian => ["apache2", "libphp5-apache2"],
-          CentOS => ["httpd", "php5"],
-
-       pkg $packages,
-         ensure => "present";
-    };
+    
+    task "prepare_system",
+      group => "frontends",
+      sub {
+      my $packages = case operating_system,
+        Debian => [ "apache2", "libphp5-apache2" ],
+        CentOS => [ "httpd",   "php5" ],
+    
+        pkg $packages, ensure => "present";
+      };
     ```

--- a/content/docs/rex_book/working_with_files_and_packages/installing_packages.md
+++ b/content/docs/rex_book/working_with_files_and_packages/installing_packages.md
@@ -11,8 +11,8 @@ Installing packages is easy. You can use the pkg function for this.
     password "f00b4r";
 
     task "prepare_system", group => "frontends", sub {
-       pkg "apache2",
-         ensure => "present";
+       pkg "apache2",
+         ensure => "present";
     };
     ```
 
@@ -25,8 +25,8 @@ If you have to install multiple packages you can use an array so that you don't 
     password "f00b4r";
 
     task "prepare_system", group => "frontends", sub {
-       pkg ["apache2", "libphp5-apache2", "mysql-server"],
-         ensure => "present";
+       pkg ["apache2", "libphp5-apache2", "mysql-server"],
+         ensure => "present";
     };
     ```
 
@@ -39,11 +39,11 @@ If you need to write a distribution independent module you can also use the case
     password "f00b4r";
 
     task "prepare_system", group => "frontends", sub {
-       my $packages = case operating_system,
-          Debian => ["apache2", "libphp5-apache2"],
-          CentOS => ["httpd", "php5"],
+       my $packages = case operating_system,
+          Debian => ["apache2", "libphp5-apache2"],
+          CentOS => ["httpd", "php5"],
 
-       pkg $packages,
-         ensure => "present";
+       pkg $packages,
+         ensure => "present";
     };
     ```

--- a/content/docs/rex_book/working_with_files_and_packages/working_with_files.md
+++ b/content/docs/rex_book/working_with_files_and_packages/working_with_files.md
@@ -40,7 +40,7 @@ You can also execute code if the file was changed, for example to restart servic
     # Rexfile
     task "setup", sub {
       append_if_no_such_line "/etc/nagios/hosts.d/frontends.cfg",
-        line      => template("templates/nagios/host.cfg.tpl", %tpl_variables),
+        line      => template( "templates/nagios/host.cfg.tpl", %tpl_variables ),
         regexp    => qr/\s*host_name\s*$host/,
         on_change => sub { service nagios => "reload"; };
     };
@@ -70,19 +70,19 @@ For this you can use the Rex::Commands::Concat module from http://modules.rexify
     # Rexfile
     use Rex -feature => ['1.0'];
     use Rex::Commands::Concat;
-
+    
     task "prepare", sub {
       concat_fragment "config-header",
         target  => "/etc/some.conf",
         content => "# managed by Rex\n",
         order   => "01";
-
+    
       concat_fragment "listen-entry",
         target  => "/etc/some.conf",
         content => "Listen *:80\n",
         order   => "20";
     };
-
+    
     task "setup", sub {
       concat "/etc/some.conf",
         ensure    => "present",
@@ -102,10 +102,9 @@ If you want to manage complete files you can use the file() resource to do so. T
     ```perl
     # Rexfile
     use Rex -feature => ['1.0'];
-
+    
     task "setup", sub {
-      file "/etc/my.conf",
-        source => "files/etc/my.conf";
+      file "/etc/my.conf", source => "files/etc/my.conf";
     };
     ```
 
@@ -116,7 +115,7 @@ You can also define the permissions for the file.
     ```perl
     # Rexfile
     use Rex -feature => ['1.0'];
-
+    
     task "setup", sub {
       file "/etc/my.conf",
         source => "files/etc/my.conf",
@@ -131,13 +130,13 @@ If you want to execute a command when the file was changed, you can use the on\_
     ```perl
     # Rexfile
     use Rex -feature => ['1.0'];
-
+    
     task "setup", sub {
       file "/etc/my.conf",
-        source => "files/etc/my.conf",
-        owner  => "root",
-        group  => "root",
-        mode   => 600,
+        source    => "files/etc/my.conf",
+        owner     => "root",
+        group     => "root",
+        mode      => 600,
         on_change => sub { service mysqld => "restart"; };
     };
     ```
@@ -151,7 +150,7 @@ It is also possible to just supervise files if they are present or have special 
     ```perl
     # Rexfile
     use Rex -feature => ['1.0'];
-
+    
     task "setup", sub {
       file "/etc/my.conf",
         ensure => "present",

--- a/content/docs/rex_book/working_with_files_and_packages/working_with_files.md
+++ b/content/docs/rex_book/working_with_files_and_packages/working_with_files.md
@@ -11,7 +11,7 @@ If you need to verify that a given line exists or gets removed from a file you c
     ```perl
     # Rexfile
     task "setup", sub {
-      append_if_no_such_line "/etc/modules", "loop";
+      append_if_no_such_line "/etc/modules", "loop";
     };
     ```
 
@@ -24,9 +24,9 @@ It is also possible to define more complex rules. For example if you want to use
     ```perl
     # Rexfile
     task "setup", sub {
-      append_if_no_such_line "/etc/modprobe.d/thinkfan.conf",
-        line   => "options thinkpad_acpi fan_control=1",
-        regexp => qr{thinkpad_acpi};
+      append_if_no_such_line "/etc/modprobe.d/thinkfan.conf",
+        line   => "options thinkpad_acpi fan_control=1",
+        regexp => qr{thinkpad_acpi};
     };
     ```
 
@@ -39,10 +39,10 @@ You can also execute code if the file was changed, for example to restart servic
     ```perl
     # Rexfile
     task "setup", sub {
-      append_if_no_such_line "/etc/nagios/hosts.d/frontends.cfg",
-        line      => template("templates/nagios/host.cfg.tpl", %tpl_variables),
-        regexp    => qr/\s*host_name\s*$host/,
-        on_change => sub { service nagios => "reload"; };
+      append_if_no_such_line "/etc/nagios/hosts.d/frontends.cfg",
+        line      => template("templates/nagios/host.cfg.tpl", %tpl_variables),
+        regexp    => qr/\s*host_name\s*$host/,
+        on_change => sub { service nagios => "reload"; };
     };
     ```
 
@@ -53,8 +53,8 @@ If you need to remove a line you can use delete\_lines\_according\_to.
     ```perl
     # Rexfile
     task "setup", sub {
-      delete_lines_according_to qr{loop}, "/etc/modules",
-        on_change => sub { say "file was modified."; };
+      delete_lines_according_to qr{loop}, "/etc/modules",
+        on_change => sub { say "file was modified."; };
     };
     ```
 
@@ -72,24 +72,24 @@ For this you can use the Rex::Commands::Concat module from http://modules.rexify
     use Rex::Commands::Concat;
 
     task "prepare", sub {
-      concat_fragment "config-header",
-        target  => "/etc/some.conf",
-        content => "# managed by Rex\n",
-        order   => "01";
+      concat_fragment "config-header",
+        target  => "/etc/some.conf",
+        content => "# managed by Rex\n",
+        order   => "01";
 
-      concat_fragment "listen-entry",
-        target  => "/etc/some.conf",
-        content => "Listen *:80\n",
-        order   => "20";
+      concat_fragment "listen-entry",
+        target  => "/etc/some.conf",
+        content => "Listen *:80\n",
+        order   => "20";
     };
 
     task "setup", sub {
-      concat "/etc/some.conf",
-        ensure    => "present",
-        owner     => "root",
-        group     => "root",
-        mode      => 644,
-        on_change => sub { say "changed..."; };
+      concat "/etc/some.conf",
+        ensure    => "present",
+        owner     => "root",
+        group     => "root",
+        mode      => 644,
+        on_change => sub { say "changed..."; };
     };
     ```
 
@@ -104,8 +104,8 @@ If you want to manage complete files you can use the file() resource to do so. T
     use Rex -feature => ['1.0'];
 
     task "setup", sub {
-      file "/etc/my.conf",
-        source => "files/etc/my.conf";
+      file "/etc/my.conf",
+        source => "files/etc/my.conf";
     };
     ```
 
@@ -118,11 +118,11 @@ You can also define the permissions for the file.
     use Rex -feature => ['1.0'];
 
     task "setup", sub {
-      file "/etc/my.conf",
-        source => "files/etc/my.conf",
-        owner  => "root",
-        group  => "root",
-        mode   => 600;
+      file "/etc/my.conf",
+        source => "files/etc/my.conf",
+        owner  => "root",
+        group  => "root",
+        mode   => 600;
     };
     ```
 
@@ -133,12 +133,12 @@ If you want to execute a command when the file was changed, you can use the on\_
     use Rex -feature => ['1.0'];
 
     task "setup", sub {
-      file "/etc/my.conf",
-        source => "files/etc/my.conf",
-        owner  => "root",
-        group  => "root",
-        mode   => 600,
-        on_change => sub { service mysqld => "restart"; };
+      file "/etc/my.conf",
+        source => "files/etc/my.conf",
+        owner  => "root",
+        group  => "root",
+        mode   => 600,
+        on_change => sub { service mysqld => "restart"; };
     };
     ```
 
@@ -153,10 +153,10 @@ It is also possible to just supervise files if they are present or have special 
     use Rex -feature => ['1.0'];
 
     task "setup", sub {
-      file "/etc/my.conf",
-        ensure => "present",
-        owner  => "root",
-        group  => "root",
-        mode   => 600;
+      file "/etc/my.conf",
+        ensure => "present",
+        owner  => "root",
+        group  => "root",
+        mode   => 600;
     };
     ```

--- a/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
+++ b/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
@@ -8,9 +8,9 @@ Rex comes with a hardware gathering module. To display all the things Rex knows 
 
     ```perl
     use Rex -feature => ['1.0'];
-
+    
     task "dump-info", sub {
-       dump_system_information;
+      dump_system_information;
     };
     ```
 
@@ -90,18 +90,18 @@ To use these information inside the Rexfile you can query them with the get\_sys
 
     ```perl
     use Rex -feature => ['1.0'];
-
+    
     task "get_hostname", sub {
-       my %info = get_system_information;
-       say $info{hostname} . "." . $info{domain};
+      my %info = get_system_information;
+      say $info{hostname} . "." . $info{domain};
     };
-
+    
     use Rex -feature => ['1.0'];
-
+    
     task "prepare", sub {
-       my $libpath = case connection->server->architecture,
-                         "i386"   => "/usr/lib",
-                         "x86_64" => "/usr/lib64";
+      my $libpath = case connection->server->architecture,
+        "i386"   => "/usr/lib",
+        "x86_64" => "/usr/lib64";
     };
     ```
 

--- a/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
+++ b/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
@@ -10,7 +10,7 @@ Rex comes with a hardware gathering module. To display all the things Rex knows 
     use Rex -feature => ['1.0'];
 
     task "dump-info", sub {
-       dump_system_information;
+       dump_system_information;
     };
     ```
 
@@ -23,11 +23,11 @@ A sample output (CentOS 5.9 running inside KVM)
     $memory_total = '497'
     $kernelrelease = '2.6.18-348.6.1.el5'
     $Kernel = {
-          kernelversion => '#1 SMP Tue May 21 15:29:55 EDT 2013'
-          architecture => 'x86_64'
-          kernel => 'Linux'
-          kernelrelease => '2.6.18-348.6.1.el5'
-       }
+          kernelversion => '#1 SMP Tue May 21 15:29:55 EDT 2013'
+          architecture => 'x86_64'
+          kernel => 'Linux'
+          kernelrelease => '2.6.18-348.6.1.el5'
+       }
     $hostname = 'centos-5-amd64.rexify.org'
     $operatingsystem = 'CentOS'
     $operatingsystemrelease = '5.9'
@@ -37,30 +37,30 @@ A sample output (CentOS 5.9 running inside KVM)
     $kernel = 'Linux'
     $swap_free = '1023'
     $VirtInfo = {
-          virtualization_role => 'guest'
-          virtualization_type => 'kvm'
-       }
+          virtualization_role => 'guest'
+          virtualization_type => 'kvm'
+       }
     $memory_shared = '0'
     $Network = {
-          networkdevices => [
-             'eth0'
-          ]
-          networkconfiguration => {
-             eth0 => {
-                broadcast => '192.168.122.255'
-                ip => '192.168.122.22'
-                netmask => '255.255.255.0'
-                mac => '52:54:00:E8:69:15'
-             }
-          }
-       }
+          networkdevices => [
+             'eth0'
+          ]
+          networkconfiguration => {
+             eth0 => {
+                broadcast => '192.168.122.255'
+                ip => '192.168.122.22'
+                netmask => '255.255.255.0'
+                mac => '52:54:00:E8:69:15'
+             }
+          }
+       }
     $memory_used = '218'
     $kernelname = 'Linux'
     $Swap = {
-          free => '1023'
-          used => '0'
-          total => '1023'
-       }
+          free => '1023'
+          used => '0'
+          total => '1023'
+       }
     $swap_total = '1023'
     $memory_buffers = '12'
     $eth0_ip = '192.168.122.22'
@@ -68,23 +68,23 @@ A sample output (CentOS 5.9 running inside KVM)
     $memory_free = '278'
     $manufacturer = 'Bochs'
     $Memory = {
-          shared => '0'
-          buffers => '12'
-          free => '278'
-          used => '218'
-          total => '497'
-          cached => '127'
-       }
+          shared => '0'
+          buffers => '12'
+          free => '278'
+          used => '218'
+          total => '497'
+          cached => '127'
+       }
     $eth0_broadcast = '192.168.122.255'
     $eth0_netmask = '255.255.255.0'
     $Host = {
-          domain => ''
-          manufacturer => 'Bochs'
-          kernelname => 'Linux'
-          hostname => 'centos-5-amd64.rexify.org'
-          operatingsystemrelease => '5.9'
-          operatingsystem => 'CentOS'
-       }
+          domain => ''
+          manufacturer => 'Bochs'
+          kernelname => 'Linux'
+          hostname => 'centos-5-amd64.rexify.org'
+          operatingsystemrelease => '5.9'
+          operatingsystem => 'CentOS'
+       }
 
 To use these information inside the Rexfile you can query them with the get\_system\_information function or use the methods from the connection object
 
@@ -92,16 +92,16 @@ To use these information inside the Rexfile you can query them with the get\_sys
     use Rex -feature => ['1.0'];
 
     task "get_hostname", sub {
-       my %info = get_system_information;
-       say $info{hostname} . "." . $info{domain};
+       my %info = get_system_information;
+       say $info{hostname} . "." . $info{domain};
     };
 
     use Rex -feature => ['1.0'];
 
     task "prepare", sub {
-       my $libpath = case connection->server->architecture,
-                         "i386"   => "/usr/lib",
-                         "x86_64" => "/usr/lib64";
+       my $libpath = case connection->server->architecture,
+                         "i386"   => "/usr/lib",
+                         "x86_64" => "/usr/lib64";
     };
     ```
 

--- a/content/docs/rex_book/writing_modules/writing_custom_resources.md
+++ b/content/docs/rex_book/writing_modules/writing_custom_resources.md
@@ -66,10 +66,10 @@ The *\_\_module\_\_.pm* file which creates the resource.
     use strict;
     use warnings;
     
-    use Rex -minimal; # for Rex < 1.4 use Rex -base;
+    use Rex -minimal;          # for Rex < 1.4 use Rex -base;
     use Rex::Resource::Common; # load resource functions
     
-    # load the Gather functions, so we have the `operating_system` 
+    # load the Gather functions, so we have the `operating_system`
     # function.
     use Rex::Commands::Gather;
     
@@ -86,7 +86,7 @@ The *\_\_module\_\_.pm* file which creates the resource.
       my $rule_name = resource_name;
     
       my $rule_config = {
-        ensure  => param_lookup( "ensure", "present" ),
+        ensure  => param_lookup( "ensure",  "present" ),
         message => param_lookup( "message", "<default value>" ),
       };
     
@@ -97,7 +97,7 @@ The *\_\_module\_\_.pm* file which creates the resource.
     
       # load the provider class
       $provider->require;
-      
+    
       # create a new instance of the provider class
       my $provider_o = $provider->new();
     
@@ -160,16 +160,16 @@ bare class by our self.
     # the ensure methods
     sub present {
       my ( $self, $rule_config ) = @_;
-      
+    
       my $changed = 0;
-      
+    
       file "/etc/motd",
-        content => $rule_config->{message},
-        owner   => "root",
-        group   => "root",
-        mode    => '0644',
+        content   => $rule_config->{message},
+        owner     => "root",
+        group     => "root",
+        mode      => '0644',
         on_change => sub { $changed = 1; };
-        
+    
       return $changed;
     }
     
@@ -177,11 +177,11 @@ bare class by our self.
       my ( $self, $rule_config ) = @_;
     
       my $changed = 0;
-      
+    
       file "/etc/motd",
         ensure    => "absent",
         on_change => sub { $changed = 1; };
-        
+    
       return $changed;
     }
     
@@ -206,9 +206,9 @@ purpose how to do inheritance.
     sub new {
       my $that  = shift;
       my $proto = ref($that) || $that;
-      
+    
       # here we call the constructor of the parent class
-      my $self  = $proto->SUPER::new(@_);
+      my $self = $proto->SUPER::new(@_);
     
       bless( $self, $proto );
     
@@ -231,13 +231,15 @@ resource in your `Rexfile`.
     
     group myservers => "srv[01..10]";
     
-    task "prepare", group => "myservers", sub {
+    task "prepare",
+      group => "myservers",
+      sub {
       HelloWorld::greet "mygreeting",
-        message => "Welcome to my server",
-        ensure  => "present",
+        message   => "Welcome to my server",
+        ensure    => "present",
         on_change => sub {
-          say "server greeting has changed.";
+        say "server greeting has changed.";
         };
-    };
+      };
     ```
 

--- a/content/index.md
+++ b/content/index.md
@@ -70,16 +70,18 @@ If this task gets executed against a "virgin" host (where no Apache is installed
     group frontend => "frontend[01..05]";
     
     desc "Prepare Frontend Server";
-    task "prepare", group => "frontend", sub {
-      pkg "apache2",
-        ensure => "latest";
+    task "prepare",
+      group => "frontend",
+      sub {
+      pkg "apache2", ensure => "latest";
     
-      service "apache2",
-        ensure => "started";
-    };
+      service "apache2", ensure => "started";
+      };
     
     desc "Keep Configuration in sync";
-    task "configure", group => "frontend", sub {
+    task "configure",
+      group => "frontend",
+      sub {
       prepare();
     
       file "/etc/apache2/apache2.conf",
@@ -101,20 +103,22 @@ You can also run everything with sudo. Just define the sudo password and activat
     sudo_password "mysudopw";
     
     desc "Prepare Frontend Server";
-    task "prepare", group => "frontend", sub {
-      pkg "apache2",
-        ensure => "latest";
+    task "prepare",
+      group => "frontend",
+      sub {
+      pkg "apache2", ensure => "latest";
     
-      service "apache2",
-        ensure => "started";
-    };
+      service "apache2", ensure => "started";
+      };
     
     desc "Keep Configuration in sync";
-    task "configure", group => "frontend", sub {
+    task "configure",
+      group => "frontend",
+      sub {
       prepare();
     
       file "/etc/apache2/apache2.conf",
         source    => "files/etc/apache2/apache2.conf",
         on_change => sub { service apache2 => "reload"; };
-    };
+      };
     ```

--- a/misc/tidy_codeblocks
+++ b/misc/tidy_codeblocks
@@ -1,0 +1,55 @@
+#!/bin/env perl
+
+use strict;
+use warnings;
+use feature 'say';
+
+use Path::Tiny;
+use Perl::Tidy;
+
+# copy arguments to keep perltidy happy
+my @files = @ARGV;
+@ARGV = ();
+
+for my $file (@files) {
+  my $text = path($file)->slurp;
+
+  $text =~ s/
+        (?<=```perl\n)
+        (?<code>.+?)
+        (?=\n\s+```)
+    /
+        tidy($+{code});
+    /egmsx;
+
+  path($file)->spew($text);
+}
+
+sub tidy {
+  my $code = shift;
+  my $result;
+  my $stderr;
+
+  my ($indent) = $code =~ m{^(\s+)};
+
+  $code =~ s/^$indent//gm; # remove indent
+
+  my $error = Perl::Tidy::perltidy(
+    source      => \$code,
+    destination => \$result,
+    errorfile   => \$stderr,
+  );
+
+  if ( defined $stderr ) {
+    say 'CODE';
+    say $code;
+
+    say 'ERROR';
+    say $stderr;
+  }
+
+  $result =~ s/^/$indent/gm; # add back indent
+  chomp $result;             # remove trailing newline
+
+  return $result;
+}


### PR DESCRIPTION
While working on the sytax highlighting topic, I noticed that the code blocks could use some updates. This PR aims to improve the situation by the following:

- add a `misc/tidy_codeblocks` script

    This basically extracts fenced perl code blocks from a document and passes them through perltidy in a way that preserves the original code block indent too. Then replaces the original code block with the tidied one.

    Question: this depends on `Perl::Tidy`, do we want to add that to `cpanfile`? If yes, how it is the best to add? Perhaps some kind of author dependency?

- fix some invalid code example

   Mainly typos, but in a few cases, by converting them into full code examples instead of just fragments.

- replace all leftover non-breaking space in markdown documents

   Statocles and/or the Markdown renderer seems to be unhappy about them. I believe it's safe to just replace all of them with a normal space (note: this is the markdown source, non-breaking spaces are still fine in the generated HTML, and I beliebe `&nbsp;` is also fine in the markdown when it's a must).

- tidy up all code examples by using the script mentioned above

    This adds overall consistency for all code on the site. I'm happy to change `.perltidyrc` if needed, but I'm happy with the improvements already, so that can be handled in a different PR.