### PR TITLE
Add basic metadata for Open Graph protocol (fix #20)

### DIFF
--- a/theme/layout/default.html.ep
+++ b/theme/layout/default.html.ep
@@ -1,11 +1,16 @@
 <!DOCTYPE html
      PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<html prefix="og: http://ogp.me/ns#" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en>
    <head>
       <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 
       <title><%= $page->title %></title>
+
+      <meta property="og:title" content="<%= $page->title %>" />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="<%= $site->url($page->path) %>" />
+      <meta property="og:image" content="<%= $site->url('/public/images/skin/rexify.org/favicon.png') %>" />
 
       <meta name="viewport" content="width=1024, initial-scale=0.5">
       <link rel="shortcut icon" href="/public/images/skin/rexify.org/favicon.png" />


### PR DESCRIPTION
This PR adds basic metadata for Open Graph protocol for all pages of the website. If I understand everything correctly, this should solve #20, while opening up the way to add more metadata in the future as needed.