### PR TITLE
Point all links (including sitemap.xml) to canonical documents

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -4,7 +4,7 @@ site:
         title: (R)?ex Deployment & Configuration Management
         markdown:
             $class: Text::MultiMarkdown
-        base_url: https://rexify.org
+        base_url: https://www.rexify.org
         theme:
             $ref: rexify
         apps:


### PR DESCRIPTION
Note that urls pointing to 'https://rexify.org' are redirected
(or should be) to 'https://www.rexify.org'. Better to point
various resources there directly.