### PR TITLE
Check for valid HTML5

### DIFF
--- a/content/docs/guides/start_using__r__ex.md
+++ b/content/docs/guides/start_using__r__ex.md
@@ -6,7 +6,7 @@ This is a small howto showing the first steps with Rex.
 
 # Basic Architecture
 
-<img style="float: right;" src="/public/images/skin/rexify.org/archi.png" width="410" height="272" />
+<img style="float: right;" src="/public/images/skin/rexify.org/archi.png" alt="Basic architecture" width="410" height="272" />
 
 Rex is a server orchestration tool that doesn't need an agent on the hosts you want to manage. In fact it uses ssh to execute the given commands.
 

--- a/content/docs/rex_book/the_rex_dsl/using_environments.md
+++ b/content/docs/rex_book/the_rex_dsl/using_environments.md
@@ -8,7 +8,7 @@ You can create environments for dev, staging and production machines. There is n
 
 The classic way is to have 3 environments. The development environment for integration tests, mostly with fewest machines. The staging environment, mostly with the same resource layers as production. And the production environment.
 
-<img src="/public/images/skin/rexify.org/book_env.png" width="619" height="464" />
+<img src="/public/images/skin/rexify.org/book_env.png" alt="Environments" width="619" height="464" />
 
 ## Creating Environments
 

--- a/content/support/index.md
+++ b/content/support/index.md
@@ -25,7 +25,7 @@ Get consulting, training and custom implementation services directly from a core
 
 ### inovex - Enabling Your Digital Future
 
-<img style="float:left; padding-right: 50px; padding-bottom: 20px;" src="/public/images/skin/rexify.org/inovex_logo.png" alt="inovex" width="80" />
+<img style="float:left; padding-right: 50px; padding-bottom: 20px;" src="/public/images/skin/rexify.org/inovex_logo.png" alt="inovex" width="80" height="55" />
 
 inovex, the IT project company specialising in data center engineering, is the first company which offers professional support for Rex, thereby emphasising the key importance of open source technologies in setting up and operating modern, cost-optimised data centers.
 

--- a/content/support/index.md
+++ b/content/support/index.md
@@ -16,7 +16,7 @@ You want to provide commercial support for Rex? Just drop us a few lines with a 
 
 ### Ferenc Erki - (R)?ex Core Developer
 
-<img style="float:left; padding-right: 50px;" src="/public/images/skin/rexify.org/ferki.jpg" width="80" height="80" />
+<img style="float:left; padding-right: 50px;" src="/public/images/skin/rexify.org/ferki.jpg" alt="FErki" width="80" height="80" />
 
 Get consulting, training and custom implementation services directly from a core developer behind (R)?ex.
 
@@ -25,7 +25,7 @@ Get consulting, training and custom implementation services directly from a core
 
 ### inovex - Enabling Your Digital Future
 
-<img style="float:left; padding-right: 50px; padding-bottom: 20px;" src="/public/images/skin/rexify.org/inovex_logo.png" width="80" />
+<img style="float:left; padding-right: 50px; padding-bottom: 20px;" src="/public/images/skin/rexify.org/inovex_logo.png" alt="inovex" width="80" />
 
 inovex, the IT project company specialising in data center engineering, is the first company which offers professional support for Rex, thereby emphasising the key importance of open source technologies in setting up and operating modern, cost-optimised data centers.
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 requires 'HTML::Entities';
+requires 'HTML::Lint::Pluggable';
 requires 'Statocles';
 requires 'Syntax::Highlight::Engine::Kate';
 requires 'Text::MultiMarkdown';

--- a/lib/Statocles/Plugin/HTMLLint.pm
+++ b/lib/Statocles/Plugin/HTMLLint.pm
@@ -1,0 +1,86 @@
+package Statocles::Plugin::HTMLLint;
+our $VERSION = '0.094';
+# ABSTRACT: Check HTML for common errors and issues
+
+use Statocles::Base 'Class';
+with 'Statocles::Plugin';
+BEGIN {
+    eval { require HTML::Lint::Pluggable; HTML::Lint::Pluggable->VERSION( 0.06 ); 1 }
+        or die "Error loading Statocles::Plugin::HTMLLint. To use this plugin, install HTML::Lint::Pluggable";
+};
+
+=attr plugins
+
+The L<HTML::Lint::Pluggable> plugins to use. Defaults to a generic set of
+plugins good for HTML5: 'HTML5' and 'TinyEntitesEscapeRule'
+
+=cut
+
+has plugins => (
+    is => 'ro',
+    isa => ArrayRef,
+    default => sub { [qw( HTML5 TinyEntitesEscapeRule )] },
+);
+
+=method check_pages
+
+    $plugin->check_pages( $event );
+
+Check the pages inside the given
+L<Statocles::Event::Pages|Statocles::Event::Pages> event.
+
+=cut
+
+sub check_pages {
+    my ( $self, $event ) = @_;
+    my @plugins = @{ $self->plugins };
+
+    my $lint = HTML::Lint::Pluggable->new;
+    $lint->load_plugins( @plugins );
+
+    for my $page ( @{ $event->pages } ) {
+        if ( $page->DOES( 'Statocles::Page::Document' ) ) {
+            my $html = "".$page->dom;
+            my $page_url = $page->path;
+
+            $lint->newfile( $page_url );
+            $lint->parse( $html );
+            $lint->eof;
+        }
+    }
+
+    if ( my @errors = $lint->errors ) {
+        for my $error ( @errors ) {
+            $event->emitter->log->warn( "-" . $error->as_string );
+        }
+    }
+}
+
+=method register
+
+Register this plugin to install its event handlers. Called automatically.
+
+=cut
+
+sub register {
+    my ( $self, $site ) = @_;
+    $site->on( build => sub { $self->check_pages( @_ ) } );
+}
+
+1;
+
+=head1 SYNOPSIS
+
+    # site.yml
+    site:
+        class: Statocles::Site
+        args:
+            plugins:
+                lint:
+                    $class: Statocles::Plugin::HTMLLint
+
+=head1 DESCRIPTION
+
+This plugin checks all of the HTML to ensure it's correct and complete. If something
+is missing, this plugin will write a warning to the screen.
+

--- a/lib/Statocles/Plugin/HTMLLint/RexOps.pm
+++ b/lib/Statocles/Plugin/HTMLLint/RexOps.pm
@@ -9,6 +9,19 @@ BEGIN {
         or die "Error loading Statocles::Plugin::HTMLLint. To use this plugin, install HTML::Lint::Pluggable";
 };
 
+=attr fatal
+
+If set to true, and there are any linting errors, the plugin will also call
+C<die()> after printing the problems. Defaults to false.
+
+=cut
+
+has fatal => (
+    is => 'ro',
+    isa => Bool,
+    default => 0,
+);
+
 =attr plugins
 
 The L<HTML::Lint::Pluggable> plugins to use. Defaults to a generic set of
@@ -53,7 +66,7 @@ sub check_pages {
         for my $error ( @errors ) {
             $event->emitter->log->warn( "-" . $error->as_string );
         }
-        die "Linting failed!";
+        die "Linting failed!" if $self->fatal;
     }
 }
 
@@ -83,5 +96,6 @@ sub register {
 =head1 DESCRIPTION
 
 This plugin checks all of the HTML to ensure it's correct and complete. If something
-is missing, this plugin will write a warning to the screen.
+is missing, this plugin will write a warning to the screen. If fatal is set to true,
+it will also call C<die()> afterwards.
 

--- a/lib/Statocles/Plugin/HTMLLint/RexOps.pm
+++ b/lib/Statocles/Plugin/HTMLLint/RexOps.pm
@@ -78,7 +78,7 @@ sub register {
         args:
             plugins:
                 lint:
-                    $class: Statocles::Plugin::HTMLLint
+                    $class: Statocles::Plugin::HTMLLint::RexOps
 
 =head1 DESCRIPTION
 

--- a/lib/Statocles/Plugin/HTMLLint/RexOps.pm
+++ b/lib/Statocles/Plugin/HTMLLint/RexOps.pm
@@ -1,6 +1,6 @@
-package Statocles::Plugin::HTMLLint;
-our $VERSION = '0.094';
-# ABSTRACT: Check HTML for common errors and issues
+package Statocles::Plugin::HTMLLint::RexOps;
+our $VERSION = '0.001';
+# ABSTRACT: Check HTML for common errors and issues for the rexify-website
 
 use Statocles::Base 'Class';
 with 'Statocles::Plugin';

--- a/lib/Statocles/Plugin/HTMLLint/RexOps.pm
+++ b/lib/Statocles/Plugin/HTMLLint/RexOps.pm
@@ -53,6 +53,7 @@ sub check_pages {
         for my $error ( @errors ) {
             $event->emitter->log->warn( "-" . $error->as_string );
         }
+        die "Linting failed!";
     }
 }
 

--- a/site.yml
+++ b/site.yml
@@ -19,6 +19,7 @@ site:
                 $class: Statocles::Plugin::Highlight::RexOps
             lint:
                 $class: Statocles::Plugin::HTMLLint::RexOps
+                fatal: 1
                 plugins:
                     - HTML5
                     - RDFa

--- a/site.yml
+++ b/site.yml
@@ -17,6 +17,12 @@ site:
         plugins:
             highlight:
                 $class: Statocles::Plugin::Highlight::RexOps
+            lint:
+                $class: Statocles::Plugin::HTMLLint
+                plugins:
+                    - HTML5
+                    - RDFa
+                    - TinyEntitesEscapeRule
         deploy:
             $ref: gh_pages
         data:

--- a/site.yml
+++ b/site.yml
@@ -18,7 +18,7 @@ site:
             highlight:
                 $class: Statocles::Plugin::Highlight::RexOps
             lint:
-                $class: Statocles::Plugin::HTMLLint
+                $class: Statocles::Plugin::HTMLLint::RexOps
                 plugins:
                     - HTML5
                     - RDFa

--- a/theme/layout/default.html.ep
+++ b/theme/layout/default.html.ep
@@ -1,3 +1,4 @@
+<% use HTML::Entities; %>\
 <!DOCTYPE html
      PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -5,7 +6,7 @@
    <head>
       <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 
-      <title><%= $page->title %></title>
+      <title><%== encode_entities($page->title) %></title>
 
       <meta property="og:title" content="<%= $page->title %>" />
       <meta property="og:type" content="website" />


### PR DESCRIPTION
This PR enables HTML5 linting of the generated pages, and fails hard if there are any problems.

The built-in linter plugin simply prints warnings, but otherwise continues happily. In order to make it more useful with our Travis pipeline, I decided to simply import the standard plugin and patched it to fail on errors instead.

This patch could be made optional, and then it might be a good candidate to send upstream. If there's a better/simpler approach to override the behavior, don't hesitate to let me know :)