### PR TITLE
Revamp contributing information

### DIFF
--- a/content/care/help__r__ex.md
+++ b/content/care/help__r__ex.md
@@ -2,29 +2,22 @@
 title: Contribute to (R)?ex
 ---
 
-There is no company behind (R)?ex. Everything is developed by volunteers around the globe during their free time. (R)?ex is a free, open source project. Every contribution is welcome.
+There is no company behind (R)?ex. As a free and open source project, it is developed by volunteers around the globe. Every contribution is welcome.
 
-## Get in contact
+## Code and documentation
 
-You'll find us on irc.freenode.net in the \#rex channel. Just be a bit patient, it might take a few minutes until someone answers.
+If you would like to contribute code or documentation to (R)?ex, please read our [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md).
 
-## Documentation
+## Website
 
-The success of every project is its documentation. If there is no documentation a project won't be successful. So one part where you can help is writing user friendly documentation.
-It is often hard to find a good balance between documenting new features (or removing deprecated documentation) and writing new code. So if you find outdated documentation, want to add guides, tweak the design or rewrite the complete webpage, don't hesitate to contact us.
-You can clone the website code from GitHub. Please read the README file on how to get the website up and running on your local machine.
-
-## Code
-
-If you want to contribute new functionality or fix things, you can just clone the repository on GitHub and send pull requests against the development branch. We encourage you to logically group your commits together in topic/feature branches and send a pull request for each of them. We also appreciate nicely formatted and meaningful commit messages, for example something like described here.
-We use perltidy to help us to maintain a consequent code style throughout the project (check out our .perltidyrc for more details). We recommend setting it up with your favorite IDE or text editor, so you can apply formatting easily or even automatically to your changes before committing them.
-If you have any questions about how to implement something, join us on irc.freenode.net / \#rex.
+If you would like to contribute to this website, please read this [README](https://github.com/RexOps/rexify-website/blob/master/README.md).
 
 ## Sponsoring
 
-As mentioned above (R)?ex is completely developed by volunteers. Which means there is no guarantee that a specific feature will be released at a defined date. If you need a special feature you can sponsor it, so we can focus our efforts on that feature. In this case contact us at feature@rexify.org.
-Those sponsored features will also be released under the same license as (R)?ex itself. So it is guaranteed that it will remain  compatible with following releases and you will also have the benefit of a community finding potential bugs or contributing enhancements.
+Since (R)?ex is completely developed by volunteers, there is no guarantee that a specific feature will be released at a defined date. If you need a specific feature, you can sponsor it, so we may focus our efforts on that feature. Those sponsored features will also be released under the same license as (R)?ex itself, to guarantee that it will be maintained like any other feature. Please contact us for further details.
+
+If you are looking for something custom-made, you may be interested in checking out our [Support page](/support/index.html).
 
 ## Hardware
 
-One special case is hardware. There can't be enough hardware/environments where we can test (R)?ex. Especially given our plans about Rex.IO and rex-jobcontrol - a bare metal deployer and webfrontend for (R)?ex. If you can donate any kind of hardware please contact us at sponsor@rexify.org.
+There can't be enough hardware where we can test and build (R)?ex. If you can donate any kind of hardware, please contact us.


### PR DESCRIPTION
This PR aims to make the contributing information on the website both simpler and more up-to-date.

Since we have nice resources to learn about how to contribute to various aspects of the project, I think it makes sense to just simply link to them in order to avoid duplication (and to avoid the need to maintain the same info in multiple places).

So I did that for the code, docs and website topics, and cleaned up + reworded the rest.