### PR TITLE
Update perltidy rules

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,5 +1,5 @@
 --ignore-side-comment-lengths
---indent-columns=2
+--variable-maximum-line-length
 --minimum-space-to-comment=1
 --no-outdent-long-quotes
 --no-outdent-long-comments

--- a/content/docs/faq/index.md
+++ b/content/docs/faq/index.md
@@ -35,9 +35,9 @@ If you want to print the output to your terminal you have to call it in a scalar
 
     ```perl
     task 'mytask', sub {
-      my $parameters       = shift;
-      my $parameter1_value = $parameters->{parameter1};
-      my $parameter2_value = $parameters->{parameter2};
+        my $parameters       = shift;
+        my $parameter1_value = $parameters->{parameter1};
+        my $parameter2_value = $parameters->{parameter2};
     };
     ```
 
@@ -57,7 +57,7 @@ Then, you can run your shell code remotely as:
     use Rex::Misc::ShellBlock;
     
     task "myexec", sub {
-      shell_block <<EOF;
+        shell_block <<EOF;
         echo "hi"
     EOF
     };
@@ -72,7 +72,7 @@ If you have a local script 'files/script', you can run it on the remote using th
     ```perl
     use Rex::Misc::ShellBlock;
     task "myexec", sub {
-      shell_block template('files/script');
+        shell_block template('files/script');
     };
     ```
 
@@ -83,12 +83,12 @@ Given the same scenario as above, but with the additional requirement to run the
     ```perl
     use Rex::Misc::ShellBlock;
     task "myexec", sub {
-      sudo {
-        command => sub {
-          shell_block template('files/script');
-        },
-        user => 'root'
-      };
+        sudo {
+            command => sub {
+                shell_block template('files/script');
+            },
+            user => 'root'
+        };
     };
     ```
 

--- a/content/docs/guides/cheat_sheet/index.md
+++ b/content/docs/guides/cheat_sheet/index.md
@@ -59,7 +59,7 @@ Manage files on remote systems.
           group     => "root",
           mode      => 644,
           on_change => sub {
-          service ntpd => "restart";
+            service ntpd => "restart";
           };
         ```
 
@@ -76,7 +76,7 @@ Install a package on the remote system.
         pkg "ntpd",
           ensure    => "latest",
           on_change => sub {
-          service ntpd => "restart";
+            service ntpd => "restart";
           };
         ```
 

--- a/content/docs/guides/cloud_management/manage_your_amazon_ec2_instances.md
+++ b/content/docs/guides/cloud_management/manage_your_amazon_ec2_instances.md
@@ -41,11 +41,11 @@ Insert the following code in your new Rexfile.
     cloud_region "ec2.eu-west-1.amazonaws.com";
     
     task "create", sub {
-      cloud_instance create => {
-        image_id => "ami-02103876",
-        name     => "static01",
-        key      => "dev-test",
-      };
+        cloud_instance create => {
+            image_id => "ami-02103876",
+            name     => "static01",
+            key      => "dev-test",
+        };
     };
     ```
 
@@ -57,14 +57,14 @@ Sometimes you need an instance with a persistent storage volume. To achieve this
 
     ```perl
     task "create", sub {
-      my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a", };
-      cloud_instance create => {
-        image_id => "ami-02103876",
-        name     => "static01",
-        key      => "dev-test",
-        volume   => $vol_id,
-        zone     => "eu-west-1a",
-      };
+        my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a", };
+        cloud_instance create => {
+            image_id => "ami-02103876",
+            name     => "static01",
+            key      => "dev-test",
+            volume   => $vol_id,
+            zone     => "eu-west-1a",
+        };
     };
     ```
 
@@ -74,8 +74,8 @@ To get a list of all regions and zone you can use the following functions.
 
     ```perl
     task "list", sub {
-      print Dumper get_cloud_regions;
-      print Dumper get_cloud_availability_zones;
+        print Dumper get_cloud_regions;
+        print Dumper get_cloud_availability_zones;
     };
     ```
 
@@ -85,8 +85,8 @@ To get a list of all your instances and volumes you can use these functions.
 
     ```perl
     task "list", sub {
-      print Dumper cloud_instance_list;
-      print Dumper cloud_volume_list;
+        print Dumper cloud_instance_list;
+        print Dumper cloud_volume_list;
     };
     ```
 
@@ -96,8 +96,8 @@ If you don't need your instances or volumes anymore, you can just destroy them.
 
     ```perl
     task "destroy", sub {
-      cloud_volume delete      => "$volume_id";
-      cloud_instance terminate => "$instance_id";
+        cloud_volume delete      => "$volume_id";
+        cloud_instance terminate => "$instance_id";
     };
     ```
 
@@ -117,20 +117,20 @@ Now we need to add some software to our fresh EC2 instance.
     task "prepare",
       group => "ec2",
       sub {
-      run "apt-get update";
-      install package => "apache2";
+        run "apt-get update";
+        install package => "apache2";
     
-      service apache2 => "ensure", "started";
+        service apache2 => "ensure", "started";
     
-      # deploy your webapp, see Rex::Apache::Deploy for more information.
-      deploy "my-site.tar.gz";
+        # deploy your webapp, see Rex::Apache::Deploy for more information.
+        deploy "my-site.tar.gz";
     
-      # or upload some files
-      file "/etc/passwd", source => "/etc/passwd";
+        # or upload some files
+        file "/etc/passwd", source => "/etc/passwd";
     
-      # do what ever you want
-      use Rex::Commands::Iptables;
-      close_port "all";
+        # do what ever you want
+        use Rex::Commands::Iptables;
+        close_port "all";
       };
     ```
 

--- a/content/docs/guides/just_enough_perl_for_rex.md
+++ b/content/docs/guides/just_enough_perl_for_rex.md
@@ -54,7 +54,7 @@ If you want to iterate over an array, do it like this:
 
     ```perl
     for my $name (@names) {
-      say "Current name: $name"; # double quotes make variables interpolated
+        say "Current name: $name"; # double quotes make variables interpolated
     }
     ```
 
@@ -64,8 +64,8 @@ Hashes are like arrays, but with named indexes, called keys.
 
     ```perl
     my %person = (
-      name => 'John',
-      age  => 28,    # good practice to keep a trailing comma
+        name => 'John',
+        age  => 28,    # good practice to keep a trailing comma
     );
     ```
 
@@ -80,7 +80,7 @@ If you want to iterate over a hash, do it like this:
 
     ```perl
     for my $key ( keys %person ) {
-      say "key: $key -> value: " . $person{$key};
+        say "key: $key -> value: " . $person{$key};
     }
     ```
 
@@ -90,27 +90,27 @@ But remember an important note: hashes are always unsorted.
 
     ```perl
     if ( $name eq 'John' ) {
-      say 'Hello, my name is John!';
+        say 'Hello, my name is John!';
     }
     else {
-      say 'Well, my name is not John...';
+        say 'Well, my name is not John...';
     }
     
     if ( $name ne 'John' ) {
-      say 'Well, my name is not John...';
+        say 'Well, my name is not John...';
     }
     else {
-      say 'Hello, my name is John!';
+        say 'Hello, my name is John!';
     }
     
     if ( $age < 30 ) {
-      say 'I am younger than 30.';
+        say 'I am younger than 30.';
     }
     elsif ( $age >= 30 && $age <= 50 ) {
-      say 'Well, I am between 30 and 50.';
+        say 'Well, I am between 30 and 50.';
     }
     else {
-      say 'I am older than 50.';
+        say 'I am older than 50.';
     }
     ```
 
@@ -118,12 +118,12 @@ But remember an important note: hashes are always unsorted.
 
     ```perl
     for my $num ( 1 .. 5 ) {
-      say "> $num";
+        say "> $num";
     }
     
     # looping over an array
     for my $item (@array) {
-      say "> $item";
+        say "> $item";
     }
     ```
 
@@ -149,7 +149,7 @@ But remember an important note: hashes are always unsorted.
     }
     
     sub my_function2 { # @_ contains the parameters passed to the subroutine
-      my ( $param1, $param2 ) = @_;
+        my ( $param1, $param2 ) = @_;
     }
     
     my_function();     # call the function 'my_function'

--- a/content/docs/guides/start_using__r__ex.md
+++ b/content/docs/guides/start_using__r__ex.md
@@ -57,8 +57,8 @@ Now change into this directory and create a file called Rexfile with the followi
     task 'uptime',
       group => 'myservers',
       sub {
-      my $output = run 'uptime';
-      say $output;
+        my $output = run 'uptime';
+        say $output;
       };
     ```
 
@@ -77,7 +77,7 @@ To add a second task, just add the next lines to your Rexfile.
     task 'start_apache',
       group => 'myservers',
       sub {
-      service 'apache2' => 'start';
+        service 'apache2' => 'start';
       };
     ```
 
@@ -143,15 +143,15 @@ In this example you will learn how to install and configure an NTP server. You c
     task 'setup_ntp',
       group => 'all_servers',
       sub {
-      pkg 'ntpd', ensure => 'present'; # let's install the package first
+        pkg 'ntpd', ensure => 'present'; # let's install the package first
     
-      file '/etc/ntp.conf',            # then upload a configuration file
-        source => 'files/etc/ntp.conf', # use a source file under files/etc
-        on_change => sub { # and execute something if the file has changed
-        service ntpd => 'restart'; # in this case, restart the service
-        };
+        file '/etc/ntp.conf',            # then upload a configuration file
+          source => 'files/etc/ntp.conf', # use a source file under files/etc
+          on_change => sub { # and execute something if the file has changed
+            service ntpd => 'restart'; # in this case, restart the service
+          };
     
-      service 'ntpd', ensure => 'started'; # start the service now and also after reboot
+        service 'ntpd', ensure => 'started'; # start the service now and also after reboot
       };
     ```
 

--- a/content/docs/guides/using_modules_and_templates.md
+++ b/content/docs/guides/using_modules_and_templates.md
@@ -30,19 +30,19 @@ This file is a normal Perl module. The only special thing is the filename, but d
     use Rex -feature => ['1.3'];
     
     task prepare => sub {
-      my $service_name = case operating_system, {
-        Debian    => "ntp",
-          default => "ntpd",
-      };
-      pkg "ntp", ensure => "present";
-    
-      file "/etc/ntp.conf",
-        source    => "files/etc/ntp.conf",
-        on_change => sub {
-        service $service_name => "restart";
+        my $service_name = case operating_system, {
+            Debian    => "ntp",
+              default => "ntpd",
         };
+        pkg "ntp", ensure => "present";
     
-      service $service_name, ensure => "started";
+        file "/etc/ntp.conf",
+          source    => "files/etc/ntp.conf",
+          on_change => sub {
+            service $service_name => "restart";
+          };
+    
+        service $service_name, ensure => "started";
     };
     
     1;
@@ -90,27 +90,27 @@ But if you want to change a parameter in your ntp.conf file you have to edit 4 f
     use Rex -feature => ['1.0'];
     
     task prepare => sub {
-      my $service_name = case operating_system, {
-        Debian    => "ntp",
-          default => "ntpd",
-      };
-    
-      my $ntp_server = case environment, {
-        prod      => [ "ntp01.company.tld", "ntp02.company.tld" ],
-          preprod => ["ntp01.preprod.company.tld"],
-          test    => ["ntp01.test.company.tld"],
-          default => ["ntp01.company.tld"],
-      };
-    
-      pkg "ntp", ensure => "present";
-    
-      file "/etc/ntp.conf",
-        content   => template( "files/etc/ntp.conf", ntp_servers => $ntp_server ),
-        on_change => sub {
-        service $service_name => "restart";
+        my $service_name = case operating_system, {
+            Debian    => "ntp",
+              default => "ntpd",
         };
     
-      service $service_name, ensure => "started";
+        my $ntp_server = case environment, {
+            prod      => [ "ntp01.company.tld", "ntp02.company.tld" ],
+              preprod => ["ntp01.preprod.company.tld"],
+              test    => ["ntp01.test.company.tld"],
+              default => ["ntp01.company.tld"],
+        };
+    
+        pkg "ntp", ensure => "present";
+    
+        file "/etc/ntp.conf",
+          content   => template( "files/etc/ntp.conf", ntp_servers => $ntp_server ),
+          on_change => sub {
+            service $service_name => "restart";
+          };
+    
+        service $service_name, ensure => "started";
     };
     
     1;
@@ -137,7 +137,7 @@ There are also some predefined variables you can use in your templates. For exam
 
     ```perl
     task "get_infos", "server01", sub {
-      dump_system_information;
+        dump_system_information;
     };
     ```
 

--- a/content/docs/guides/working_with_packages.md
+++ b/content/docs/guides/working_with_packages.md
@@ -11,7 +11,7 @@ To install a package you can use the `pkg` function.
 
     ```perl
     task "prepare", "server1", sub {
-      pkg "apache2", ensure => "present";
+        pkg "apache2", ensure => "present";
     };
     ```
 
@@ -19,7 +19,7 @@ If you want to install multiple packages you can do it by providing an array ref
 
     ```perl
     task "prepare", "server1", sub {
-      pkg [qw/apache2 vim php5/], ensure => "present";
+        pkg [qw/apache2 vim php5/], ensure => "present";
     };
     ```
 
@@ -27,7 +27,7 @@ If you want to install a special version of a package you just need to specify t
 
     ```perl
     task "prepare", "server1", sub {
-      pkg "apache2", ensure => "2.2.4";
+        pkg "apache2", ensure => "2.2.4";
     };
     ```
 
@@ -37,7 +37,7 @@ If you don't need a package anymore you can remove it with the remove function.
 
     ```perl
     task "prepare", "server1", sub {
-      pkg "apache2", ensure => "absent";
+        pkg "apache2", ensure => "absent";
     };
     ```
 
@@ -50,12 +50,12 @@ Sometimes you have to add custom repositories to your Server. This can be done w
     ```perl
     task "prepare", "server2", sub {
     
-      # add a repository for debian/ubuntu
-      repository
-        add        => "myrepo",
-        url        => "http://foo.bar/repo",
-        distro     => "squeeze",
-        repository => "stable";
+        # add a repository for debian/ubuntu
+        repository
+          add        => "myrepo",
+          url        => "http://foo.bar/repo",
+          distro     => "squeeze",
+          repository => "stable";
     };
     ```
 
@@ -64,10 +64,10 @@ Sometimes you have to add custom repositories to your Server. This can be done w
     ```perl
     task "prepare", "server2", sub {
     
-      # add a repository for redhat/centos
-      repository
-        add => "myrepo",
-        url => "http://foo.bar/repo";
+        # add a repository for redhat/centos
+        repository
+          add => "myrepo",
+          url => "http://foo.bar/repo";
     };
     ```
 
@@ -76,13 +76,13 @@ After you've added a new repository you need to run update\_package\_db to updat
     ```perl
     task "prepare", "server2", sub {
     
-      # add a repository for redhat/centos
-      repository
-        add => "myrepo",
-        url => "http://foo.bar/repo";
+        # add a repository for redhat/centos
+        repository
+          add => "myrepo",
+          url => "http://foo.bar/repo";
     
-      # update package database
-      update_package_db;
+        # update package database
+        update_package_db;
     };
     ```
 

--- a/content/docs/release_notes/0.10.md
+++ b/content/docs/release_notes/0.10.md
@@ -23,14 +23,14 @@ title: Release notes for 0.10
 
         ```perl
         task "mount", "server01", sub {
-          mount "/dev/sda5", "/tmp";
-          mount "/dev/sda6", "/mnt/sda6",
-            fs      => "ext3",
-            options => [qw/noatime async/];
+            mount "/dev/sda5", "/tmp";
+            mount "/dev/sda6", "/mnt/sda6",
+              fs      => "ext3",
+              options => [qw/noatime async/];
         };
         
         task "umount", "server01", sub {
-          umount "/tmp";
+            umount "/tmp";
         };
         ```
 
@@ -42,11 +42,11 @@ title: Release notes for 0.10
         cron
           add => "root",
           {
-          minute       => '5',
-          hour         => '*',
-          day_of_month => '*',
-          month        => '*',
-          day_of_week  => '*',
+            minute       => '5',
+            hour         => '*',
+            day_of_month => '*',
+            month        => '*',
+            day_of_week  => '*',
           };
         
         cron list => "root";
@@ -65,10 +65,10 @@ title: Release notes for 0.10
         ```perl
         task "get-installed", "server1", sub {
         
-          for my $pkg ( installed_packages() ) {
-            say "name     : " . $pkg->{"name"};
-            say "  version: " . $pkg->{"version"};
-          }
+            for my $pkg ( installed_packages() ) {
+                say "name     : " . $pkg->{"name"};
+                say "  version: " . $pkg->{"version"};
+            }
         
         };
     ```

--- a/content/docs/release_notes/0.11.md
+++ b/content/docs/release_notes/0.11.md
@@ -10,9 +10,9 @@ title: Release notes for 0.11
         use Rex::Commands::LVM;
         
         task "lvm", sub {
-          my @physical_devices = pvs;
-          my @volume_groups    = vgs;
-          my @logical_volumes  = lvs;
+            my @physical_devices = pvs;
+            my @volume_groups    = vgs;
+            my @logical_volumes  = lvs;
         };
         ```
 
@@ -24,11 +24,11 @@ title: Release notes for 0.11
 
         ```perl
         task "db", sub {
-          my @data = db select => {
-            fields => "*",
-            from   => "table",
-            order  => "updated DESC",
-          };
+            my @data = db select => {
+                fields => "*",
+                from   => "table",
+                order  => "updated DESC",
+            };
         };
         ```
 

--- a/content/docs/release_notes/0.12.md
+++ b/content/docs/release_notes/0.12.md
@@ -10,7 +10,7 @@ title: Release notes for 0.12
         sudo_password "mypassword";
         
         task "dosomething", sub {
-          say sudo "id";
+            say sudo "id";
         };
         ```
 
@@ -18,7 +18,7 @@ title: Release notes for 0.12
 
         ```perl
         task "start", sub {
-          service [qw/apache2 rsyslog ftp/] => "start";
+            service [qw/apache2 rsyslog ftp/] => "start";
         };
         ```
 
@@ -27,8 +27,8 @@ title: Release notes for 0.12
         ```perl
         use Rex::Commands::Iptables;
         task "prepare", sub {
-          service apache2 => "ensure", "started";
-          service apache2 => "ensure", "stopped";
+            service apache2 => "ensure", "started";
+            service apache2 => "ensure", "stopped";
         };
         ```
 
@@ -37,42 +37,42 @@ title: Release notes for 0.12
         ```perl
         task "firewall", sub {
         
-          # clear all rules
-          iptables_clear;
+            # clear all rules
+            iptables_clear;
         
-          # open port 22 on all devices
-          open_port 22;
+            # open port 22 on all devices
+            open_port 22;
         
-          # open port 22 and 80 on eth0
-          open_port [ 22, 80 ] => { dev => "eth0", };
+            # open port 22 and 80 on eth0
+            open_port [ 22, 80 ] => { dev => "eth0", };
         
-          # close all ports on all devices
-          close_port "all";
+            # close all ports on all devices
+            close_port "all";
         
-          # close port 22 on dev eth0
-          close_port 22 => { dev => "eth0", };
+            # close port 22 on dev eth0
+            close_port 22 => { dev => "eth0", };
         
-          # redirect port 80 to 10080
-          redirect_port 80 => 10080;
+            # redirect port 80 to 10080
+            redirect_port 80 => 10080;
         
-          # redirect port 80 to 10080 on eth0
-          redirect_port 80 => {
-            dev => "eth0",
-            to  => 10080,
-          };
+            # redirect port 80 to 10080 on eth0
+            redirect_port 80 => {
+                dev => "eth0",
+                to  => 10080,
+            };
         
-          # set default state rules (RELATED,ESTABLISHED) to accept on all devices
-          default_state_rule;
+            # set default state rules (RELATED,ESTABLISHED) to accept on all devices
+            default_state_rule;
         
-          # set default state rules (RELATED,ESTABLISHED) to accept on eth0
-          default_state_rule dev => "eth0";
+            # set default state rules (RELATED,ESTABLISHED) to accept on eth0
+            default_state_rule dev => "eth0";
         
-          # make the system a nat gateway for its default route
-          # this will set the sysctl entry net.ipv4.ip_forward to 1, too.
-          is_nat_gateway;
+            # make the system a nat gateway for its default route
+            # this will set the sysctl entry net.ipv4.ip_forward to 1, too.
+            is_nat_gateway;
         
-          # define a custom iptables rule
-          iptables t => "filter", A => "INPUT", i => "eth0", ...;
+            # define a custom iptables rule
+            iptables t => "filter", A => "INPUT", i => "eth0", ...;
         };
         ```
 
@@ -99,40 +99,40 @@ title: Release notes for 0.12
         group ec2 => get_cloud_instances_as_group();
         
         task "list", sub {
-          print Dumper cloud_instances_list;
-          print Dumper cloud_volume_list;
+            print Dumper cloud_instances_list;
+            print Dumper cloud_volume_list;
         
-          print Dumper get_cloud_regions;
-          print Dumper get_cloud_availability_zones;
+            print Dumper get_cloud_regions;
+            print Dumper get_cloud_availability_zones;
         };
         
         task "create", sub {
         
-          # if you want an ebs volume, create it. if not, you don't need this.
-          my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a"; };
+            # if you want an ebs volume, create it. if not, you don't need this.
+            my $vol_id = cloud_volume create => { size => 1, zone => "eu-west-1a"; };
         
-          # create the cloud instances and attach the just created ebs volume.
-          cloud_instance create => {
-            image_id => "ami-02103876",
-            name     => "test-ec2",
-            key      => "my-test-key",
-            volume   => $vol_id,       # if you don't have a volume, skip this
-            zone => "eu-west-1a", # the volume and the instance must be in the same zone. skip this if you don't have a volume.
-          };
+            # create the cloud instances and attach the just created ebs volume.
+            cloud_instance create => {
+                image_id => "ami-02103876",
+                name     => "test-ec2",
+                key      => "my-test-key",
+                volume   => $vol_id,       # if you don't have a volume, skip this
+                zone => "eu-west-1a", # the volume and the instance must be in the same zone. skip this if you don't have a volume.
+            };
         };
         
         task "destroy", sub {
-          cloud_volume detach      => "vol-xxaabb";
-          cloud_instance terminate => "i-ffgghhjj";
-          cloud_colume delete      => "vol-xxaabb";
+            cloud_volume detach      => "vol-xxaabb";
+            cloud_instance terminate => "i-ffgghhjj";
+            cloud_colume delete      => "vol-xxaabb";
         };
         
         task "prepare",
           group => "ec2",
           sub {
-          run "apt-get update";
-          install package => "apache2";
-          service apache2 => "start";
+            run "apt-get update";
+            install package => "apache2";
+            service apache2 => "start";
           };
         ```
 

--- a/content/docs/release_notes/0.13.md
+++ b/content/docs/release_notes/0.13.md
@@ -23,19 +23,19 @@ title: Release notes for 0.13
         group jiffybox => get_cloud_instances_as_group();
         
         task "create", sub {
-          cloud_instance create => {
-            image_id => "debian_squeeze_64bit",
-            name     => "test01",
-            plan_id  => 10,
-            password => "f00b4r",
-          };
+            cloud_instance create => {
+                image_id => "debian_squeeze_64bit",
+                name     => "test01",
+                plan_id  => 10,
+                password => "f00b4r",
+            };
         };
         
         task "prepare",
           group => "jiffybox",
           sub {
-          update_package_db;
-          install package => "apache2";
+            update_package_db;
+            install package => "apache2";
           };
         ```
 
@@ -45,7 +45,7 @@ title: Release notes for 0.13
 
         ```perl
         task "update", "server1", "server2", sub {
-          update_package_db;
+            update_package_db;
         };
         ```
 
@@ -53,17 +53,17 @@ title: Release notes for 0.13
 
         ```perl
         task "test", "server1", "server2", sub {
-          unlink "/tmp/doesntexists"; # this will terminate the whole execution because it will fail.
+            unlink "/tmp/doesntexists"; # this will terminate the whole execution because it will fail.
         
-          # this will catch the exception and store it in $@
-          eval {
-            unlink "/tmp/doesntexists";
+            # this will catch the exception and store it in $@
+            eval {
+                unlink "/tmp/doesntexists";
         
-            # and more stuff
-          } or do {
-            say "Tried to unlink /tmp/doesntexists but it failed.";
-            say "Error: $@";
-          };
+                # and more stuff
+            } or do {
+                say "Tried to unlink /tmp/doesntexists but it failed.";
+                say "Error: $@";
+            };
         };
         ```
 

--- a/content/docs/release_notes/0.17.md
+++ b/content/docs/release_notes/0.17.md
@@ -22,8 +22,8 @@ title: Release notes for 0.17
         
         task "prepare", "server1", "server2", sub {
         
-          # if solaris, install apache-22 from Blastwave
-          install package => "apache-22";
+            # if solaris, install apache-22 from Blastwave
+            install package => "apache-22";
         };
         ```
 
@@ -35,8 +35,8 @@ title: Release notes for 0.17
         
         task "prepare", "server1", "server2", sub {
         
-          # if solaris, install apache-22 from OpenCSW
-          install package => "apache-22";
+            # if solaris, install apache-22 from OpenCSW
+            install package => "apache-22";
         };
         ```
 
@@ -58,7 +58,7 @@ title: Release notes for 0.17
 
         ```perl
         task "prepare-services", "server1", "server2", sub {
-          service ssh => "restart";
+            service ssh => "restart";
         };
         ```
 
@@ -69,7 +69,7 @@ title: Release notes for 0.17
         service_provider_for SunOS => "svcadm";
         
         task "prepare-services", "server1", "server2", sub {
-          service ssh => "restart";
+            service ssh => "restart";
         };
         ```
 
@@ -77,9 +77,9 @@ title: Release notes for 0.17
 
         ```perl
         task "prepare", "server1", "server2", sub {
-          if ( operating_system_version() < 10 ) {
-            say "too old...";
-          }
+            if ( operating_system_version() < 10 ) {
+                say "too old...";
+            }
         };
         ```
 

--- a/content/docs/release_notes/0.19.md
+++ b/content/docs/release_notes/0.19.md
@@ -26,23 +26,23 @@ title: Release notes for 0.19
         # define live environment, with different user/password
         # and a frontend server group containing www01, www02 and www03
         environment live => sub {
-          user "root";
-          password "livefoo";
-          pass_auth;
+            user "root";
+            password "livefoo";
+            pass_auth;
         
-          group frontend => "www01", "www02", "www03";
+            group frontend => "www01", "www02", "www03";
         };
         
         # define stage environment with default user and password, but with
         # an own frontend group containing only stagewww01
         environment stage => sub {
-          group frontend => "stagewww01";
+            group frontend => "stagewww01";
         };
         
         task "prepare",
           group => "frontend",
           sub {
-          say run "hostname";
+            say run "hostname";
           };
         ```
 

--- a/content/docs/release_notes/0.21.md
+++ b/content/docs/release_notes/0.21.md
@@ -14,7 +14,7 @@ title: Release notes for 0.21
           url        => "git@foo.bar:myrepo.git";
         
         task "checkout", sub {
-          checkout "myrepo";
+            checkout "myrepo";
         };
         ```
 
@@ -29,7 +29,7 @@ title: Release notes for 0.21
         task "prepare",
           group => [ "frontend", "backend" ],
           sub {
-          say run "uptime";
+            say run "uptime";
           };
         ```
 
@@ -41,12 +41,12 @@ title: Release notes for 0.21
         
         task "prepare", "server1", sub {
         
-          # will authenticate as root/test
+            # will authenticate as root/test
         };
         
         task "prepare2", "server1", sub {
         
-          # will also authenticate as root/test
+            # will also authenticate as root/test
         };
         
         # all tasks from here down will authenticate as deploy/testdeploy
@@ -54,7 +54,7 @@ title: Release notes for 0.21
         password "testdeploy";
         task "deploy", "server1", sub {
         
-          # will authenticate as deploy/testdeploy
+            # will authenticate as deploy/testdeploy
         };
         ```
 
@@ -64,9 +64,9 @@ title: Release notes for 0.21
 
         ```perl
         task "createuser", "server1", sub {
-          create_user "foo",
-            home    => "/home/foo",
-            ssh_key => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB...";
+            create_user "foo",
+              home    => "/home/foo",
+              ssh_key => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB...";
         };
         ```
 
@@ -84,7 +84,7 @@ title: Release notes for 0.21
         port 2222;
         task "prepare", "server1", "server2", sub {
         
-          # will always connect to port 2222
+            # will always connect to port 2222
         };
         ```
 
@@ -92,7 +92,7 @@ title: Release notes for 0.21
 
         ```perl
         task "upload", "server1", sub {
-          file "/etc/passwd", source => "files/etc/passwd";
+            file "/etc/passwd", source => "files/etc/passwd";
         };
         ```
 

--- a/content/docs/release_notes/0.22.md
+++ b/content/docs/release_notes/0.22.md
@@ -11,19 +11,19 @@ title: Release notes for 0.22
             prepare => "server1",
             "server2", sub {
           
-            # do something
+              # do something
             };
           
           before prepare => sub {
-            my ($server) = @_;
-            say "Starting virtual machine...";
-            run "xm start $server";
+              my ($server) = @_;
+              say "Starting virtual machine...";
+              run "xm start $server";
           };
           
           after prepare => sub {
-            my ( $server, $failed_connection ) = @_;
-            say "Stopping virtual machine...";
-            run "xm stop $server";
+              my ( $server, $failed_connection ) = @_;
+              say "Stopping virtual machine...";
+              run "xm stop $server";
           };
           ```
 
@@ -36,12 +36,12 @@ title: Release notes for 0.22
           ```perl
           task prepare_user => sub {
           
-            create_user "foo" => {
-              home           => '/home/foo',
-              groups         => [ 'users', '...' ],
-              crypt_password => '$1$.yBAfj8a$mQ2SY/lfz8FaSUTgHsP37c/',
-              ssh_key        => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChUw...",
-            };
+              create_user "foo" => {
+                  home           => '/home/foo',
+                  groups         => [ 'users', '...' ],
+                  crypt_password => '$1$.yBAfj8a$mQ2SY/lfz8FaSUTgHsP37c/',
+                  ssh_key        => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChUw...",
+              };
           
           };
           ```

--- a/content/docs/release_notes/0.24.md
+++ b/content/docs/release_notes/0.24.md
@@ -13,15 +13,15 @@ title: Release notes for 0.24
         use Rex::Commands::Pkg;
         
         Rex::connect(
-          server      => "remotehost",
-          user        => "root",
-          private_key => "/home/jan/.ssh/id_rsa",
-          public_key  => "/home/jan/.ssh/id_rsa.pub",
+            server      => "remotehost",
+            user        => "root",
+            private_key => "/home/jan/.ssh/id_rsa",
+            public_key  => "/home/jan/.ssh/id_rsa.pub",
         );
         
         if ( is_file("/etc/sudoers") ) {
         
-          # do something
+            # do something
         }
         
         install package => "apache2";
@@ -40,7 +40,7 @@ title: Release notes for 0.24
 
         ```perl
         task "foo", sub {
-          file "/etc/foo", content => template( "@mytemplate.conf", user => 'bar', );
+            file "/etc/foo", content => template( "@mytemplate.conf", user => 'bar', );
         };
         
          __DATA__
@@ -56,15 +56,15 @@ title: Release notes for 0.24
 
         ```perl
         task "foo", sub {
-          my ($param) = shift;
+            my ($param) = shift;
         
-          # ...
+            # ...
         };
         
         before foo => sub {
-          my ( $server, $server_ref, $param ) = @_;
+            my ( $server, $server_ref, $param ) = @_;
         
-          # do something before "foo"
+            # do something before "foo"
         };
         ```
 

--- a/content/docs/release_notes/0.26.md
+++ b/content/docs/release_notes/0.26.md
@@ -14,11 +14,11 @@ title: Release notes for 0.26
         sudo -on; # turn sudo globally on
         
         task prepare => sub {
-          install "apache2";
-          file "/etc/ntp.conf",
-            source => "files/etc/ntp.conf",
-            owner  => "root",
-            mode   => 640;
+            install "apache2";
+            file "/etc/ntp.conf",
+              source => "files/etc/ntp.conf",
+              owner  => "root",
+              mode   => 640;
         };
         ```
 
@@ -26,15 +26,14 @@ title: Release notes for 0.26
 
         ```perl
         task prepare => sub {
-          file "/tmp/foo.txt",
-            content => "this file was written without sudo privileges\n";
+            file "/tmp/foo.txt",
+              content => "this file was written without sudo privileges\n";
         
-          # everything in this section will be executed with sudo privileges
-          sudo sub {
-            install "apache2";
-            file "/tmp/foo2.txt",
-              content => "this file was written with sudo privileges\n";
-          };
+            # everything in this section will be executed with sudo privileges
+            sudo sub {
+                install "apache2";
+                file "/tmp/foo2.txt", content => "this file was written with sudo privileges\n";
+            };
         };
         ```
 
@@ -44,7 +43,7 @@ title: Release notes for 0.26
         include qw/Webserver::Apache Database::MySQL/;
         
         task prepare => sub {
-          Webserver::Apache::setup();
+            Webserver::Apache::setup();
         };
         ```
 
@@ -52,7 +51,7 @@ title: Release notes for 0.26
 
         ```perl
         task foo => sub {
-          sed qr{search}, "replace", "/path/to/file";
+            sed qr{search}, "replace", "/path/to/file";
         };
         ```
 
@@ -60,10 +59,10 @@ title: Release notes for 0.26
 
         ```perl
         task prepare => sub {
-          install "foo";
+            install "foo";
         
-          # old way
-          install package => "foo";
+            # old way
+            install package => "foo";
         };
         ```
 
@@ -71,7 +70,7 @@ title: Release notes for 0.26
 
         ```perl
         task prepare => sub {
-          extract "/tmp/myfile.tar.gz", chdir => "/etc";
+            extract "/tmp/myfile.tar.gz", chdir => "/etc";
         };
         ```
 
@@ -81,7 +80,7 @@ title: Release notes for 0.26
 
         ```perl
         task graceful_apache => sub {
-          service httpd => "graceful";
+            service httpd => "graceful";
         };
         ```
 

--- a/content/docs/release_notes/0.27.md
+++ b/content/docs/release_notes/0.27.md
@@ -10,10 +10,10 @@ title: Release notes for 0.27
 
         ```perl
         task "foo", sub {
-          run "ls -l ", sub {
-            my ( $stdout, $stderr ) = @_;
-            print ">> $stdout\n";
-          };
+            run "ls -l ", sub {
+                my ( $stdout, $stderr ) = @_;
+                print ">> $stdout\n";
+            };
         };
         ```
 
@@ -31,9 +31,9 @@ title: Release notes for 0.27
 
         ```perl
         task "foo", sub {
-          sed qr{search}, "replace", "/var/log/auth.log", on_change => sub {
-            say "file was changed";
-          };
+            sed qr{search}, "replace", "/var/log/auth.log", on_change => sub {
+                say "file was changed";
+            };
         };
         ```
 

--- a/content/docs/release_notes/0.28.md
+++ b/content/docs/release_notes/0.28.md
@@ -22,8 +22,8 @@ title: Release notes for 0.28
 
         ```perl
         task "syncr", "server1", sub {
-          sync "/packages/www", "/var/www/html",
-            { parameters => "--backup --delete ...", };
+            sync "/packages/www", "/var/www/html",
+              { parameters => "--backup --delete ...", };
         };
         ```
 

--- a/content/docs/release_notes/0.29.md
+++ b/content/docs/release_notes/0.29.md
@@ -32,8 +32,8 @@ title: Release notes for 0.29
 
         ```perl
         BEGIN {
-          use Rex::Shared::Var;
-          share(qw($scalar @array %hash));
+            use Rex::Shared::Var;
+            share(qw($scalar @array %hash));
         }
         ```
 

--- a/content/docs/release_notes/0.3.md
+++ b/content/docs/release_notes/0.3.md
@@ -13,13 +13,13 @@ title: Release notes for 0.3
         
         desc "Sync /etc";
         task "etc", "server1", "server2", "server3", sub {
-          sync "/filestore/public/etc", "/etc";
+            sync "/filestore/public/etc", "/etc";
         };
         
         Or, if you want to sync a remote directory to a local one
         
           task "get-logs", "server", sub {
-          sync "/var/log", "/tmp/logs", { download => 1 };
+            sync "/var/log", "/tmp/logs", { download => 1 };
           };
         ```
 
@@ -49,7 +49,7 @@ title: Release notes for 0.3
 
         ```perl
         task "uname", "www[1..10]", sub {
-          run "uname -a";
+            run "uname -a";
         };
         
           or
@@ -59,7 +59,7 @@ title: Release notes for 0.3
         task "uname",
           group => "webserver",
           sub {
-          run "uname -a";
+            run "uname -a";
           };
         ```
 
@@ -85,12 +85,12 @@ title: Release notes for 0.3
 
         ```perl
         task "hostname", "server1", "server2", sub {
-          run "hostname";
-          do_task "uname";
+            run "hostname";
+            do_task "uname";
         };
         
         task "uname", "server1", "server2", sub {
-          run "uname -a";
+            run "uname -a";
         };
         ```
 

--- a/content/docs/release_notes/0.30.md
+++ b/content/docs/release_notes/0.30.md
@@ -28,7 +28,7 @@ title: Release notes for 0.30
         task "foo",
           group => "myservers",
           sub {
-          # print do something
+            # print do something
           };
         Rex::TaskList->get_task("foo")->set_parallelism(10);
         ```
@@ -39,8 +39,8 @@ title: Release notes for 0.30
         task "foo",
           group => "myservers",
           sub {
-          append_if_no_such_line "/etc/groups", "mygroup:*:100:myuser1,myuser2",
-            on_change => sub { print "/etc/groups was changed...\n"; };
+            append_if_no_such_line "/etc/groups", "mygroup:*:100:myuser1,myuser2",
+              on_change => sub { print "/etc/groups was changed...\n"; };
           };
         ```
 

--- a/content/docs/release_notes/0.31.md
+++ b/content/docs/release_notes/0.31.md
@@ -50,7 +50,7 @@ title: Release notes for 0.31
         task "prepare",
           group => [ "frontends", "backends" ],
           sub {
-          # do something
+            # do something
           };
         
         auth for => "prepare" => user => "root";

--- a/content/docs/release_notes/0.33.md
+++ b/content/docs/release_notes/0.33.md
@@ -56,27 +56,27 @@ title: Release notes for 0.33
         # old
         task prepare => sub {
         
-          # do something
+            # do something
         };
         
         # new
         task prepare => make {
         
-          # do something
+            # do something
         };
         
         # old
         task "prepare",
           group => "foo",
           sub {
-          # do something
+            # do something
           };
         
         # new
         task "prepare",
           group => "foo",
           make {
-          # do something
+            # do something
           };
         ```
 
@@ -112,20 +112,20 @@ title: Release notes for 0.33
         use Template;
         
         set template_function => sub {
-          my ( $content, $vars ) = @_;
-          my $t = Template->new;
-          my $out;
-          $t->process( \$content, $vars, \$out );
-          return $out;
+            my ( $content, $vars ) = @_;
+            my $t = Template->new;
+            my $out;
+            $t->process( \$content, $vars, \$out );
+            return $out;
         };
         
         task foo => sub {
-          file "/etc/foo/service.conf",
-            content => template(
-            "service.conf.tpl",
-            name => "foo",
-            port => 1903
-            );
+            file "/etc/foo/service.conf",
+              content => template(
+                "service.conf.tpl",
+                name => "foo",
+                port => 1903
+              );
         };
         ```
 

--- a/content/docs/release_notes/0.35.md
+++ b/content/docs/release_notes/0.35.md
@@ -46,9 +46,9 @@ A website where you can download prebuilt Boxes and find information about Rex/B
         vm
           create  => "vm01",
           storage => [
-          {
-            file => "/mnt/data/vbox/vm01.img",
-          }
+            {
+                file => "/mnt/data/vbox/vm01.img",
+            }
           ],
           memory => 512,
           type   => "Linux26",
@@ -65,45 +65,45 @@ Functions to easily work with VirtualBox images.
     
     task "init", sub {
     
-      my $param = shift;
+        my $param = shift;
     
-      box {
-        my ($box) = @_;
-        $box->name( $param->{name} );
-        $box->url( $param->{url} );
-        $box->network(
-          1 => {
-            type => "nat",
-          }
-        );
+        box {
+            my ($box) = @_;
+            $box->name( $param->{name} );
+            $box->url( $param->{url} );
+            $box->network(
+                1 => {
+                    type => "nat",
+                }
+            );
     
-        # only works with network type = nat
-        # if an ssh key is present, rex will use this to log into the vm
-        # you need this if you don't run VirtualBox on your local host.
-        $box->forward_port( ssh => [ 2222 => 22 ] );
+            # only works with network type = nat
+            # if an ssh key is present, rex will use this to log into the vm
+            # you need this if you don't run VirtualBox on your local host.
+            $box->forward_port( ssh => [ 2222 => 22 ] );
     
-        $box->share_folder( "myhome" => "/home/jan" );
+            $box->share_folder( "myhome" => "/home/jan" );
     
-        $box->auth(
-          user     => "root",
-          password => "box",
-        );
+            $box->auth(
+                user     => "root",
+                password => "box",
+            );
     
-        $box->setup(qw/install_webserver/);
-      };
+            $box->setup(qw/install_webserver/);
+        };
     
     };
     
     task "down", sub {
     
-      my $param = shift;
+        my $param = shift;
     
-      my $box = Rex::Commands::Box->new( name => $param->{name} );
-      $box->stop;
+        my $box = Rex::Commands::Box->new( name => $param->{name} );
+        $box->stop;
     };
     
     task "install_webserver", sub {
-      install "apache2";
+        install "apache2";
     };
     ```
 
@@ -127,21 +127,21 @@ Functions to easily work with VirtualBox images.
 
         ```perl
         task "add-repo", "server1", "server2", sub {
-          repository add => myrepo => {
-            Ubuntu => {
-              url        => "http://foo.bar/repo",
-              distro     => "precise",
-              repository => "foo",
-            },
-            Debian => {
-              url        => "http://foo.bar/repo",
-              distro     => "squeeze",
-              repository => "foo",
-            },
-            CentOS => {
-              url => "http://foo.bar/repo",
-            },
-          };
+            repository add => myrepo => {
+                Ubuntu => {
+                    url        => "http://foo.bar/repo",
+                    distro     => "precise",
+                    repository => "foo",
+                },
+                Debian => {
+                    url        => "http://foo.bar/repo",
+                    distro     => "squeeze",
+                    repository => "foo",
+                },
+                CentOS => {
+                    url => "http://foo.bar/repo",
+                },
+            };
         };
         ```
 
@@ -151,33 +151,33 @@ It is also possible to add an **after** hook like this:
 
     ```perl
     task "add-repo", "server1", "server2", sub {
-      repository add => myrepo => {
-        Ubuntu => {
-          url        => "http://foo.bar/repo",
-          distro     => "precise",
-          repository => "foo",
-          after      => sub {
+        repository add => myrepo => {
+            Ubuntu => {
+                url        => "http://foo.bar/repo",
+                distro     => "precise",
+                repository => "foo",
+                after      => sub {
     
-            # import gpg key
-          },
-        },
-        Debian => {
-          url        => "http://foo.bar/repo",
-          distro     => "squeeze",
-          repository => "foo",
-          after      => sub {
+                    # import gpg key
+                },
+            },
+            Debian => {
+                url        => "http://foo.bar/repo",
+                distro     => "squeeze",
+                repository => "foo",
+                after      => sub {
     
-            # import gpg key
-          },
-        },
-        CentOS => {
-          url   => "http://foo.bar/repo",
-          after => sub {
+                    # import gpg key
+                },
+            },
+            CentOS => {
+                url   => "http://foo.bar/repo",
+                after => sub {
     
-            # import gpg key
-          },
-        },
-      };
+                    # import gpg key
+                },
+            },
+        };
     };
     ```
 

--- a/content/docs/release_notes/0.36.md
+++ b/content/docs/release_notes/0.36.md
@@ -25,36 +25,36 @@ You can download OpenNebula module with the following command:
     cloud_region "http://172.16.120.131:2633/RPC2";
     
     task "list-os", sub {
-      print Dumper get_cloud_operating_systems;
+        print Dumper get_cloud_operating_systems;
     };
     
     task "create", sub {
-      my $params = shift;
-      my $vm     = cloud_instance create => {
-        image => "template-1",
-        name  => $params->{name},
-      };
+        my $params = shift;
+        my $vm     = cloud_instance create => {
+            image => "template-1",
+            name  => $params->{name},
+        };
     
-      print Dumper($vm);
+        print Dumper($vm);
     };
     
     task "start", sub {
-      my $params = shift;
-      cloud_instance start => $params->{name};
+        my $params = shift;
+        cloud_instance start => $params->{name};
     };
     
     task "stop", sub {
-      my $params = shift;
-      cloud_instance stop => $params->{name};
+        my $params = shift;
+        cloud_instance stop => $params->{name};
     };
     
     task "terminate", sub {
-      my $params = shift;
-      cloud_instance terminate => $params->{name};
+        my $params = shift;
+        cloud_instance terminate => $params->{name};
     };
     
     task "list", sub {
-      print Dumper cloud_instance_list;
+        print Dumper cloud_instance_list;
     };
     ```
 
@@ -65,17 +65,17 @@ With this function you can run a specific task on a given host and get the outpu
     ```perl
     task "prepare", "server5", sub {
     
-      # do something
-      my $free_mem = run_task "get_free_mem", on => "server3";
-      if ( $free_mem < 100 ) {
-        say "Less than 100 MB free mem on server3";
+        # do something
+        my $free_mem = run_task "get_free_mem", on => "server3";
+        if ( $free_mem < 100 ) {
+            say "Less than 100 MB free mem on server3";
     
-        # create a new server instance on server5 to unload server3
-      }
+            # create a new server instance on server5 to unload server3
+        }
     };
     
     task "get_free_mem", sub {
-      return memory->{free};
+        return memory->{free};
     };
     ```
 

--- a/content/docs/release_notes/0.37.md
+++ b/content/docs/release_notes/0.37.md
@@ -20,26 +20,26 @@ You can use thise module by installing it via *rexify*.
       bash # rexify mynewproject --use=Rex::DNS::Bind
     
       set dns => {
-      server   => "127.0.0.1",
-      key_name => "mysuperkey",
-      key      => "/foobar==",
+        server   => "127.0.0.1",
+        key_name => "mysuperkey",
+        key      => "/foobar==",
       };
     
     task sometask => sub {
-      Rex::DNS::Bind::add_record(
-        domain => "rexify.org",
-        host   => "foobar01",
-        data   => "127.0.0.4",
-      );
+        Rex::DNS::Bind::add_record(
+            domain => "rexify.org",
+            host   => "foobar01",
+            data   => "127.0.0.4",
+        );
     
-      Rex::DNS::Bind::delete_record(
-        domain => "rexify.org",
-        host   => "foobar01",
-        type   => "A",
-      );
+        Rex::DNS::Bind::delete_record(
+            domain => "rexify.org",
+            host   => "foobar01",
+            type   => "A",
+        );
     
-      my @entries = Rex::DNS::Bind::list_entries( domain => "rexify.org" );
-      print Dumper( \@entries );
+        my @entries = Rex::DNS::Bind::list_entries( domain => "rexify.org" );
+        print Dumper( \@entries );
     };
     ```
 
@@ -49,14 +49,14 @@ See [Rex::DNS::Bind](http://modules.rexify.org/module/Rex::DNS::Bind) for the AP
 
         ```perl
         task "taskone", sub {
-          run_task "tasktwo",
-            on     => "foo",
-            params => { key1 => "value1", key2 => "value2" };
+            run_task "tasktwo",
+              on     => "foo",
+              params => { key1 => "value1", key2 => "value2" };
         };
         
         task "tasktwo", sub {
-          my $param = shift;
-          print Dumper($param);
+            my $param = shift;
+            print Dumper($param);
         };
         ```
 

--- a/content/docs/release_notes/0.38.md
+++ b/content/docs/release_notes/0.38.md
@@ -20,8 +20,8 @@ title: Release notes for 0.38
 
         ```perl
         task "update_all", "server1", sub {
-          update_package_db;
-          update_system;
+            update_package_db;
+            update_system;
         };
         ```
 
@@ -82,16 +82,16 @@ title: Release notes for 0.38
         ```perl
         task "prepare_boxes", sub {
         
-          # this will create a defined boxes from the YAML file.
-          boxes "init";
+            # this will create a defined boxes from the YAML file.
+            boxes "init";
         };
         
         task "stop_boxes", sub {
-          boxes stop => qw/box1 box2/;
+            boxes stop => qw/box1 box2/;
         };
         
         task "start_boxes", sub {
-          boxes start => qw/box1 box2/;
+            boxes start => qw/box1 box2/;
         };
         ```
 

--- a/content/docs/release_notes/0.39.md
+++ b/content/docs/release_notes/0.39.md
@@ -27,9 +27,9 @@ It supports basic authentication. If you don't need authentication you can omit 
 
         ```perl
         task "checkit", "server1", sub {
-          if ( is_installed("vim") ) {
-            say "vim is already installed.";
-          }
+            if ( is_installed("vim") ) {
+                say "vim is already installed.";
+            }
         };
         ```
 

--- a/content/docs/release_notes/0.4.md
+++ b/content/docs/release_notes/0.4.md
@@ -14,9 +14,9 @@ title: Release notes for 0.4
         
         desc "Get Hardware Information";
         task "hw-info", "testsystem", sub {
-          my %hw = Rex::Hardware->get(qw/ Host Kernel Memory Network Swap /);
+            my %hw = Rex::Hardware->get(qw/ Host Kernel Memory Network Swap /);
         
-          print Dumper( \%hw );
+            print Dumper( \%hw );
         };
         ```
 
@@ -24,49 +24,49 @@ title: Release notes for 0.4
 
         ```perl
         $VAR1 = {
-          'Network' => {
-            'networkdevices'       => [ 'eth0', 'wlan0' ],
-            'networkconfiguration' => {
-              'wlan0' => {
-                'broadcast' => '192.168.2.255',
-                'ip'        => '192.168.2.229',
-                'netmask'   => '255.255.255.0',
-                'mac'       => '00:21:5C:5C:1E:5F'
-              },
-              'eth0' => {
-                'broadcast' => undef,
-                'ip'        => undef,
-                'netmask'   => undef,
-                'mac'       => '00:1C:25:94:B0:85'
-              }
+            'Network' => {
+                'networkdevices'       => [ 'eth0', 'wlan0' ],
+                'networkconfiguration' => {
+                    'wlan0' => {
+                        'broadcast' => '192.168.2.255',
+                        'ip'        => '192.168.2.229',
+                        'netmask'   => '255.255.255.0',
+                        'mac'       => '00:21:5C:5C:1E:5F'
+                    },
+                    'eth0' => {
+                        'broadcast' => undef,
+                        'ip'        => undef,
+                        'netmask'   => undef,
+                        'mac'       => '00:1C:25:94:B0:85'
+                    }
+                }
+            },
+            'Memory' => {
+                'shared'  => '0',
+                'buffers' => '36',
+                'free'    => '3168',
+                'used'    => '792',
+                'total'   => '3961',
+                'cached'  => '407'
+            },
+            'Kernel' => {
+                'kernelversion' => '#1 SMP PREEMPT 2011-02-21 10:34:10 +0100',
+                'architecture'  => 'x86_64',
+                'kernel'        => 'Linux',
+                'kernelrelease' => '2.6.37.1-1.2-desktop'
+            },
+            'Swap' => {
+                'free'  => '3812',
+                'used'  => '0',
+                'total' => '3812'
+            },
+            'Host' => {
+                'domain'                 => 'site',
+                'manufacturer'           => 'LENOVO',
+                'hostname'               => 'linux-ymf0.site',
+                'operatingsystemrelease' => '11.4',
+                'operatingsystem'        => 'SuSE'
             }
-          },
-          'Memory' => {
-            'shared'  => '0',
-            'buffers' => '36',
-            'free'    => '3168',
-            'used'    => '792',
-            'total'   => '3961',
-            'cached'  => '407'
-          },
-          'Kernel' => {
-            'kernelversion' => '#1 SMP PREEMPT 2011-02-21 10:34:10 +0100',
-            'architecture'  => 'x86_64',
-            'kernel'        => 'Linux',
-            'kernelrelease' => '2.6.37.1-1.2-desktop'
-          },
-          'Swap' => {
-            'free'  => '3812',
-            'used'  => '0',
-            'total' => '3812'
-          },
-          'Host' => {
-            'domain'                 => 'site',
-            'manufacturer'           => 'LENOVO',
-            'hostname'               => 'linux-ymf0.site',
-            'operatingsystemrelease' => '11.4',
-            'operatingsystem'        => 'SuSE'
-          }
         };
         ```
 
@@ -99,16 +99,16 @@ title: Release notes for 0.4
           group => "test",
           sub {
         
-          # check if operating system is CentOS, because on CentOS vim is
-          # available through the package "vim-enhanced".
-          if ( operating_system_is("CentOS") ) {
-            install package => "vim-enhanced";
-          }
-          else {
-            install package => "vim";
-          }
+            # check if operating system is CentOS, because on CentOS vim is
+            # available through the package "vim-enhanced".
+            if ( operating_system_is("CentOS") ) {
+                install package => "vim-enhanced";
+            }
+            else {
+                install package => "vim";
+            }
         
-          install package => "mc";
+            install package => "mc";
         
           };
         ```

--- a/content/docs/release_notes/0.40.md
+++ b/content/docs/release_notes/0.40.md
@@ -13,12 +13,12 @@ The first CMDB module is based on YAML files. With this change there will be als
     use Rex::CMDB;
     
     set cmdb => {
-      type => "YAML",
-      path => getcwd() . "/cmdb",
+        type => "YAML",
+        path => getcwd() . "/cmdb",
     };
     
     task "prepare", sub {
-      my $vhosts = get cmdb "vhosts";
+        my $vhosts = get cmdb "vhosts";
     };
     ```
 
@@ -37,12 +37,12 @@ It is now possible to use VirtualBox in headless mode on MacOSX and Linux.
 
     ```perl
     set virtualization => {
-      type     => "VBox",
-      headless => TRUE
+        type     => "VBox",
+        headless => TRUE
     };
     
     task "foo", sub {
-      vm start => "myvm";
+        vm start => "myvm";
     };
     ```
 

--- a/content/docs/release_notes/0.41.md
+++ b/content/docs/release_notes/0.41.md
@@ -8,8 +8,8 @@ title: Release notes for 0.41
 
         ```perl
         task "prepare", "mysystem01", sub {
-          install "ntp";
-          say last_command_output;
+            install "ntp";
+            say last_command_output;
         };
         ```
 
@@ -17,9 +17,9 @@ title: Release notes for 0.41
 
         ```perl
         task "prepare", "mysystem01", sub {
-          my @env = cron env => user => list;
-          cron env => user => add    => { MYVAR => "foo", };
-          cron env => user => delete => "MYVAR";
+            my @env = cron env => user => list;
+            cron env => user => add    => { MYVAR => "foo", };
+            cron env => user => delete => "MYVAR";
         };
         ```
 
@@ -30,28 +30,28 @@ This module doesn't use rsync, so it works with sudo and Windows, too. And it is
     ```perl
     task "prepare", "mysystem01", sub {
     
-      # upload directory recursively to remote system.
-      sync_up "/local/directory", "/remote/directory";
+        # upload directory recursively to remote system.
+        sync_up "/local/directory", "/remote/directory";
     
-      sync_up "/local/directory", "/remote/directory", {
+        sync_up "/local/directory", "/remote/directory", {
     
-        # setting custom file permissions for every file
-        files => {
-          owner => "foo",
-          group => "bar",
-          mode  => 600,
-        },
+            # setting custom file permissions for every file
+            files => {
+                owner => "foo",
+                group => "bar",
+                mode  => 600,
+            },
     
-        # setting custom directory permissions for every directory
-        directories => {
-          owner => "foo",
-          group => "bar",
-          mode  => 700,
-        },
-      };
+            # setting custom directory permissions for every directory
+            directories => {
+                owner => "foo",
+                group => "bar",
+                mode  => 700,
+            },
+        };
     
-      # download a directory recursively from the remote system to the local machine
-      sync_down "/remote/directory", "/local/directory";
+        # download a directory recursively from the remote system to the local machine
+        sync_down "/remote/directory", "/local/directory";
     };
     ```
 
@@ -69,10 +69,10 @@ To get the hypervisor:
 
     ```perl
     task "info", "mysystem01", sub {
-      my %hw_info = Rex::Hardware->get(qw/VirtInfo/);
+        my %hw_info = Rex::Hardware->get(qw/VirtInfo/);
     
-      say "Role: " . $hw_info{VirtInfo}->{virtualization_role};
-      say "Type: " . $hw_info{VirtInfo}->{virtualization_type};
+        say "Role: " . $hw_info{VirtInfo}->{virtualization_role};
+        say "Type: " . $hw_info{VirtInfo}->{virtualization_type};
     };
     ```
 
@@ -80,13 +80,13 @@ To get the hypervisor:
 
         ```perl
         task "prepare", "myserver01", sub {
-          my $package = case operating_system, {
-            Debian    => "vim",
-              CentOS  => "vim-enhanced",
-              default => "vim",
-          };
+            my $package = case operating_system, {
+                Debian    => "vim",
+                  CentOS  => "vim-enhanced",
+                  default => "vim",
+            };
         
-          install $package;
+            install $package;
         };
         ```
 
@@ -108,12 +108,12 @@ To get the hypervisor:
 
           ```perl
           $instance = cloud_instance create => {
-            image_id        => "ami-5187bb25",
-            name            => "test01",
-            key             => "thekey",
-            zone            => "eu-west-1a",
-            type            => "m1.large",
-            security_groups => [ "alltcpfoo", "default" ],
+              image_id        => "ami-5187bb25",
+              name            => "test01",
+              key             => "thekey",
+              zone            => "eu-west-1a",
+              type            => "m1.large",
+              security_groups => [ "alltcpfoo", "default" ],
           };
           ```
 

--- a/content/docs/release_notes/0.42.md
+++ b/content/docs/release_notes/0.42.md
@@ -18,7 +18,7 @@ This fixes long standing pull request \#70.
     set connection => 'OpenSSH';
     
     task 'yourtask', 'yourserver', sub {
-      say run 'uptime';
+        say run 'uptime';
     };
     ```
 
@@ -39,10 +39,10 @@ It is now possible to use custom users for the sudo command.
 
     ```perl
     task "mytask", "server1", sub {
-      sudo {
-        user    => "foo",
-        command => "id",
-      };
+        sudo {
+            user    => "foo",
+            command => "id",
+        };
     };
     ```
 
@@ -52,9 +52,9 @@ This function is similar to delete\_lines\_matching but with an other syntax and
 
     ```perl
     task "cleanup", "server1", sub {
-      delete_lines_according_to qr{^foo:}, "/etc/passwd", on_change => sub {
-        say "removed user foo.";
-      };
+        delete_lines_according_to qr{^foo:}, "/etc/passwd", on_change => sub {
+            say "removed user foo.";
+        };
     };
     ```
 
@@ -115,7 +115,7 @@ memcache02 will use custom authentication and there will be a special option "se
     task "mytask",
       group => "memcache",
       sub {
-      say connection->server->option("services");
+        say connection->server->option("services");
       };
     ```
 

--- a/content/docs/release_notes/0.44.md
+++ b/content/docs/release_notes/0.44.md
@@ -12,7 +12,7 @@ title: Release notes for 0.44
         sayformat '%h: %s';
         
         task "test", sub {
-          say "hello world";
+            say "hello world";
         };
         ```
 
@@ -27,7 +27,7 @@ Possible formatting options:
 
         ```perl
         task "ps", "server01", sub {
-          my @list = grep { $_->{"ni"} == -5 } ps( "command", "ni" );
+            my @list = grep { $_->{"ni"} == -5 } ps( "command", "ni" );
         };
         ```
 
@@ -58,25 +58,25 @@ For example:
     use Data::Dumper;
     
     register_function_hooks {
-      before => {
-        file => sub {
-          print Dumper( \@_ );
-          print "before file\n";
-          return;
+        before => {
+            file => sub {
+                print Dumper( \@_ );
+                print "before file\n";
+                return;
+            },
+            create_user => sub {
+                print "before create_user\n";
+                die;
+            },
         },
-        create_user => sub {
-          print "before create_user\n";
-          die;
-        },
-      },
-      after => {
-        file => sub {
-          print "after file\n";
-        },
-        create_user => sub {
-          print "after create_user\n";
-        },
-      }
+        after => {
+            file => sub {
+                print "after file\n";
+            },
+            create_user => sub {
+                print "after create_user\n";
+            },
+        }
     };
     ```
 
@@ -84,11 +84,11 @@ For example:
 
         ```perl
         sync_up "files/", "/remote/folder", {
-          on_change => sub {
-            my (@changed_files) = @_;
+            on_change => sub {
+                my (@changed_files) = @_;
         
-            # do something
-          };
+                # do something
+            };
         };
         ```
 
@@ -141,7 +141,7 @@ For example:
         use Rex -feature => ['exec_autodie'];
         
         task "prepare", sub {
-          run "this-command-fails";
+            run "this-command-fails";
         };
         ```
 
@@ -185,7 +185,7 @@ For example:
         set backup_location => "backup/%h";
         
         task yourtask => sub {
-          file "/etc/foo.conf", content => "new content\n";
+            file "/etc/foo.conf", content => "new content\n";
         };
         ```
 

--- a/content/docs/release_notes/0.45.md
+++ b/content/docs/release_notes/0.45.md
@@ -29,10 +29,10 @@ Changes in the Cloud API
             my $vol_id = cloud_volume create => { size => 1, zone => "nova", };
             
             my $instance = cloud_instance create => {
-              image_id => "ccd8bcab-8ad2-4744-8227-08279fab7a42",
-              name     => "ostack01",
-              plan_id  => 2,
-              volume   => $vol_id,
+                image_id => "ccd8bcab-8ad2-4744-8227-08279fab7a42",
+                name     => "ostack01",
+                plan_id  => 2,
+                volume   => $vol_id,
             };
             ```
 
@@ -81,8 +81,8 @@ Changes in the core. These include new resources and new options for existing on
 
             ```perl
             file [
-              "/etc/rex/io/inventory/bootdevice", "/etc/rex/io/inventory/bridge",
-              "/etc/rex/io/inventory/sysinfo",    "/etc/rex/io/inventory/os"
+                "/etc/rex/io/inventory/bootdevice", "/etc/rex/io/inventory/bridge",
+                "/etc/rex/io/inventory/sysinfo",    "/etc/rex/io/inventory/os"
               ],
               owner => "root",
               group => "root",
@@ -133,8 +133,8 @@ Changes in the core. These include new resources and new options for existing on
             ```perl
             run "my_command",
               env => {
-              env_var_1 => "the value for 1",
-              env_var_2 => "the value for 2",
+                env_var_1 => "the value for 1",
+                env_var_2 => "the value for 2",
               };
             ```
 

--- a/content/docs/release_notes/0.46.md
+++ b/content/docs/release_notes/0.46.md
@@ -26,26 +26,26 @@ To create a test just create a new file inside a *t* directory: *t/base.t*.
     use Rex -base;
     
     test {
-      my $t = shift;
+        my $t = shift;
     
-      $t->name("ubuntu test");
+        $t->name("ubuntu test");
     
-      $t->base_vm("http://box.rexify.org/box/ubuntu-server-12.10-amd64.ova");
-      $t->vm_auth( user => "root", password => "box" );
+        $t->base_vm("http://box.rexify.org/box/ubuntu-server-12.10-amd64.ova");
+        $t->vm_auth( user => "root", password => "box" );
     
-      $t->run_task("setup");
+        $t->run_task("setup");
     
-      $t->has_package("vim");
-      $t->has_package("ntp");
-      $t->has_package("unzip");
-      $t->has_file("/etc/ntp.conf");
-      $t->has_service_running("ntp");
-      $t->has_content( "/etc/passwd", qr{root:x:0:}ms );
+        $t->has_package("vim");
+        $t->has_package("ntp");
+        $t->has_package("unzip");
+        $t->has_file("/etc/ntp.conf");
+        $t->has_service_running("ntp");
+        $t->has_content( "/etc/passwd", qr{root:x:0:}ms );
     
-      run "ls -l";
-      $t->ok( $? == 0, "ls -l returns success." );
+        run "ls -l";
+        $t->ok( $? == 0, "ls -l returns success." );
     
-      $t->finish;
+        $t->finish;
     };
     
     1;
@@ -68,37 +68,37 @@ With Rex/Boxes you can easily create your test environment with VirtualBox. You 
         # rex init --name=gpw --url=http://domain.tld/ubuntu-server-12.10-amd64.qcow2
         desc "Initialize and start the VM: rex init --name=vmname [--url=http://...]";
         task "init", make {
-          my $param = shift;
+            my $param = shift;
         
-          box {
-            my ($box) = @_;
-            $box->name( $param->{name} );
+            box {
+                my ($box) = @_;
+                $box->name( $param->{name} );
         
-            # where to download the base image
-            $box->url( $param->{url} );
+                # where to download the base image
+                $box->url( $param->{url} );
         
-            # default is nat
-            $box->network(
-              1 => {
-                type => "nat",
-              },
-              2 => {
-                type   => "bridged",
-                bridge => "br1",
-              }
-            );
+                # default is nat
+                $box->network(
+                    1 => {
+                        type => "nat",
+                    },
+                    2 => {
+                        type   => "bridged",
+                        bridge => "br1",
+                    }
+                );
         
-            # define the authentication to the box
-            # if you're downloading one from box.rexify.org this is the default.
-            $box->auth(
-              user     => "root",
-              password => "box",
-            );
+                # define the authentication to the box
+                # if you're downloading one from box.rexify.org this is the default.
+                $box->auth(
+                    user     => "root",
+                    password => "box",
+                );
         
-            # if you want to provision the machine,
-            # you can define the tasks to do that
-            $box->setup(qw/install_webserver/);
-          };
+                # if you want to provision the machine,
+                # you can define the tasks to do that
+                $box->setup(qw/install_webserver/);
+            };
         
         };
         ```
@@ -124,10 +124,10 @@ Changes in the Cloud API
             my $vol_id = cloud_volume create => { size => 1, };
             
             my $instance = cloud_instance create => {
-              image_id => "80fbcb55-b206-41f9-9bc2-2dd7aac6c061",
-              name     => "myvm01",
-              flavor   => "performance1-1",
-              networks => ["a733f9d7-098e-4bf1-881d-5a91e84b44bb"]; # networks is optional
+                image_id => "80fbcb55-b206-41f9-9bc2-2dd7aac6c061",
+                name     => "myvm01",
+                flavor   => "performance1-1",
+                networks => ["a733f9d7-098e-4bf1-881d-5a91e84b44bb"]; # networks is optional
             };
             
             cloud_volume
@@ -178,15 +178,12 @@ Changes in the Cloud API
         # Rexfile
         use Rex::CMDB;
         set cmdb => {
-          type => "YAML",
-          path => [
-            "cmdb/{operatingsystem}/{hostname}.yml",
-            "cmdb/{operatingsystem}/default.yml",
-            "cmdb/{environment}/{hostname}.yml",
-            "cmdb/{environment}/default.yml",
-            "cmdb/{hostname}.yml",
-            "cmdb/default.yml",
-          ],
+            type => "YAML",
+            path => [
+                "cmdb/{operatingsystem}/{hostname}.yml", "cmdb/{operatingsystem}/default.yml",
+                "cmdb/{environment}/{hostname}.yml",     "cmdb/{environment}/default.yml",
+                "cmdb/{hostname}.yml",                   "cmdb/default.yml",
+            ],
         };
         ```
 

--- a/content/docs/release_notes/0.47.0.md
+++ b/content/docs/release_notes/0.47.0.md
@@ -24,26 +24,26 @@ With Rex::Test it is possible to test your Rexfile on a local VM before executin
         set box => "KVM";
         
         test {
-          my $t = shift;
+            my $t = shift;
         
-          $t->name("ubuntu test");
+            $t->name("ubuntu test");
         
-          $t->base_vm("http://box.rexify.org/box/ubuntu-server-12.10-amd64.img");
-          $t->vm_auth( user => "root", password => "box" );
+            $t->base_vm("http://box.rexify.org/box/ubuntu-server-12.10-amd64.img");
+            $t->vm_auth( user => "root", password => "box" );
         
-          $t->run_task("setup");
+            $t->run_task("setup");
         
-          $t->has_package("vim");
-          $t->has_package("ntp");
-          $t->has_package("unzip");
-          $t->has_file("/etc/ntp.conf");
-          $t->has_service_running("ntp");
-          $t->has_content( "/etc/passwd", qr{root:x:0:}ms );
+            $t->has_package("vim");
+            $t->has_package("ntp");
+            $t->has_package("unzip");
+            $t->has_file("/etc/ntp.conf");
+            $t->has_service_running("ntp");
+            $t->has_content( "/etc/passwd", qr{root:x:0:}ms );
         
-          run "ls -l";
-          $t->ok( $? == 0, "ls -l returns success." );
+            run "ls -l";
+            $t->ok( $? == 0, "ls -l returns success." );
         
-          $t->finish;
+            $t->finish;
         };
         
         1;
@@ -81,13 +81,13 @@ With Rex::Test it is possible to test your Rexfile on a local VM before executin
 
         ```perl
         task "prepare", sub {
-          service "apache2",
-            ensure  => "started",
-            start   => "/usr/local/bin/httpd -f /etc/my/httpd.conf",
-            stop    => "killall httpd",
-            status  => "ps -efww | grep httpd",
-            restart => "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf",
-            reload  => "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf";
+            service "apache2",
+              ensure  => "started",
+              start   => "/usr/local/bin/httpd -f /etc/my/httpd.conf",
+              stop    => "killall httpd",
+              status  => "ps -efww | grep httpd",
+              restart => "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf",
+              reload  => "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf";
         };
         ```
 

--- a/content/docs/release_notes/0.51.2.md
+++ b/content/docs/release_notes/0.51.2.md
@@ -24,7 +24,7 @@ These are the changes in 0.51 release.
         ```perl
         use Rex -feature => ['0.51'];
         task "setup", make {
-          my $maxconn = get cmdb "maxconn";
+            my $maxconn = get cmdb "maxconn";
         };
         ```
 
@@ -37,7 +37,7 @@ These are the changes in 0.51 release.
         use Rex::Ext::ParamLookup;
         
         task "setup", make {
-          my $maxconn = param_lookup "maxconn", 4096;
+            my $maxconn = param_lookup "maxconn", 4096;
         };
         ```
 
@@ -81,8 +81,8 @@ These are the changes in 0.51 release.
         task "restart_services",
           group => "redis",
           make {
-          my @services = split /,/, connection->server->services;
-          service [@services] => "restart";
+            my @services = split /,/, connection->server->services;
+            service [@services] => "restart";
           };
 
      

--- a/content/docs/release_notes/0.52.1.md
+++ b/content/docs/release_notes/0.52.1.md
@@ -18,12 +18,12 @@ We welcome any feedback and if you want to help developing this webfrontend feel
 
         ```perl
         update_system on_change => sub {
-          my (@modified_packates) = @_;
-          for my $pkg (@modified_packages) {
-            say "Name: $pkg->{name}";
-            say "Version: $pkg->{version}";
-            say "Action: $pkg->{action}"; # some of updated, installed or removed
-          }
+            my (@modified_packates) = @_;
+            for my $pkg (@modified_packages) {
+                say "Name: $pkg->{name}";
+                say "Version: $pkg->{version}";
+                say "Action: $pkg->{action}"; # some of updated, installed or removed
+            }
         };
         ```
 
@@ -42,11 +42,11 @@ We welcome any feedback and if you want to help developing this webfrontend feel
         ```perl
         before_task_start mytask => sub {
         
-          # do some things
+            # do some things
         };
         after_task_finished mytask => sub {
         
-          # do some things
+            # do some things
         };
         ```
 
@@ -57,17 +57,17 @@ We welcome any feedback and if you want to help developing this webfrontend feel
         ```perl
         auth
           fallback => {
-          user        => "fallback_user1",
-          password    => "fallback_pw1",
-          public_key  => "",
-          private_key => "",
+            user        => "fallback_user1",
+            password    => "fallback_pw1",
+            public_key  => "",
+            private_key => "",
           },
           {
-          user        => "fallback_user2",
-          password    => "fallback_pw2",
-          public_key  => "keys/public.key",
-          private_key => "keys/private.key",
-          sudo        => TRUE,
+            user        => "fallback_user2",
+            password    => "fallback_pw2",
+            public_key  => "keys/public.key",
+            private_key => "keys/private.key",
+            sudo        => TRUE,
           };
         ```
 

--- a/content/docs/release_notes/0.53.1.md
+++ b/content/docs/release_notes/0.53.1.md
@@ -37,23 +37,23 @@ A first version of the Rex::JobControl Webfrontend will also be released in the 
         package BaseSystem;
         use Rex::Resource::Common;
         resource "motd", sub {
-          my ($params) = @_;
-          my $name = resource_name;
+            my ($params) = @_;
+            my $name = resource_name;
         
-          if ( $params->{ensure} eq "present" ) {
+            if ( $params->{ensure} eq "present" ) {
         
-            # do some things.
-            if ( !is_file($name) ) {
-              file $name, content => $params->{content};
-              emit changed;
+                # do some things.
+                if ( !is_file($name) ) {
+                    file $name, content => $params->{content};
+                    emit changed;
+                }
             }
-          }
-          elsif ( $params->{ensure} eq "absent" ) {
-            if ( is_file($name) ) {
-              rm $name;
-              emit changed;
+            elsif ( $params->{ensure} eq "absent" ) {
+                if ( is_file($name) ) {
+                    rm $name;
+                    emit changed;
+                }
             }
-          }
         };
         ```
 
@@ -62,13 +62,13 @@ A first version of the Rex::JobControl Webfrontend will also be released in the 
         ```perl
         use BaseSystem;
         task "setup", sub {
-          BaseSystem::motd "/etc/motd",
-            ensure    => present,
-            content   => "Hello World.",
-            on_change => sub {
+            BaseSystem::motd "/etc/motd",
+              ensure    => present,
+              content   => "Hello World.",
+              on_change => sub {
         
-            # do something when changed event was triggered
-            };
+                # do something when changed event was triggered
+              };
         };
         ```
 

--- a/content/docs/release_notes/0.54.3.md
+++ b/content/docs/release_notes/0.54.3.md
@@ -16,30 +16,30 @@ path\_map is a new feature developed by Erik Huelsmann to ease the management of
     use Rex -feature => ['0.54'];
     
     set path_map => {
-      "files/" => [
-        "files/{environment}/{hostname}/", "files/{environment}/",
-        "files/{hostname}/",
-      ],
-      "templates/" => [
-        "templates/{environment}/{hostname}/", "templates/{environment}/",
-        "templates/{hostname}/",
-      ],
+        "files/" => [
+            "files/{environment}/{hostname}/", "files/{environment}/",
+            "files/{hostname}/",
+        ],
+        "templates/" => [
+            "templates/{environment}/{hostname}/", "templates/{environment}/",
+            "templates/{hostname}/",
+        ],
     };
     
     task "setup",
       group => "frontends",
       sub {
-      file "/etc/security/access.conf",
-        source => "files/etc/security/access.conf",
-        owner  => "root",
-        group  => "root",
-        mode   => 644;
+        file "/etc/security/access.conf",
+          source => "files/etc/security/access.conf",
+          owner  => "root",
+          group  => "root",
+          mode   => 644;
     
-      file "/etc/ntp.conf",
-        content => template("templates/etc/ntp.conf"),
-        owner   => "root",
-        group   => "root",
-        mode    => 644;
+        file "/etc/ntp.conf",
+          content => template("templates/etc/ntp.conf"),
+          owner   => "root",
+          group   => "root",
+          mode    => 644;
       };
     ```
 

--- a/content/docs/release_notes/0.57.0.md
+++ b/content/docs/release_notes/0.57.0.md
@@ -14,7 +14,7 @@ We want to thank every contributor that makes this release possible.
 
     ```perl
     task "setup", sub {
-      sync_up "local", "remote", { parse_templates => FALSE, };
+        sync_up "local", "remote", { parse_templates => FALSE, };
       }
     ```
 

--- a/content/docs/release_notes/0.8.md
+++ b/content/docs/release_notes/0.8.md
@@ -10,11 +10,11 @@ title: Release notes for 0.8
 
         ```perl
         task "change", sub {
-          chown "jan", "/home/jan", recursive => 1;
+            chown "jan", "/home/jan", recursive => 1;
         
-          chgrp "user", "/home/jan", recursive => 1;
+            chgrp "user", "/home/jan", recursive => 1;
         
-          chmod 644, "/etc/passwd";
+            chmod 644, "/etc/passwd";
         
         };
         ```
@@ -25,13 +25,13 @@ title: Release notes for 0.8
 
         ```perl
         task "manip", sub {
-          delete_lines_matching "/var/log/auth.log", matching => "root";
-          delete_lines_matching "/var/log/auth.log", matching => qr{Failed};
+            delete_lines_matching "/var/log/auth.log", matching => "root";
+            delete_lines_matching "/var/log/auth.log", matching => qr{Failed};
         
-          append_if_no_such_line "/etc/groups",
-            "mygroup:*:100:myuser1,myuser2", "mygroup";
-          append_if_no_such_line "/etc/groups",
-            "mygroup:*:100:myuser1,myuser2", qr{^mygroup};
+            append_if_no_such_line "/etc/groups",
+              "mygroup:*:100:myuser1,myuser2", "mygroup";
+            append_if_no_such_line "/etc/groups",
+              "mygroup:*:100:myuser1,myuser2", qr{^mygroup};
         };
         ```
 
@@ -41,7 +41,7 @@ title: Release notes for 0.8
 
         ```perl
         task "reload-apache", sub {
-          service apache2 => "reload";
+            service apache2 => "reload";
         };
         ```
 
@@ -51,33 +51,33 @@ title: Release notes for 0.8
 
         ```perl
         task "db", sub {
-          my @data = db select => {
-            fields => "*",
-            from   => "table",
-            where  => "enabled=1",
-          };
-        
-          db
-            insert => "table",
-            {
-            field1 => "value1",
-            field2 => "value2",
-            field3 => 5,
+            my @data = db select => {
+                fields => "*",
+                from   => "table",
+                where  => "enabled=1",
             };
         
-          db
-            update => "table",
-            {
-            set => {
-              field1 => "newvalue",
-              field2 => "newvalue2",
-            },
-            where => "id=5",
-            };
+            db
+              insert => "table",
+              {
+                field1 => "value1",
+                field2 => "value2",
+                field3 => 5,
+              };
         
-          db
-            delete => "table",
-            { where => "id < 5", };
+            db
+              update => "table",
+              {
+                set => {
+                    field1 => "newvalue",
+                    field2 => "newvalue2",
+                },
+                where => "id=5",
+              };
+        
+            db
+              delete => "table",
+              { where => "id < 5", };
         };
         ```
 

--- a/content/docs/release_notes/0.9.md
+++ b/content/docs/release_notes/0.9.md
@@ -17,18 +17,18 @@ title: Release notes for 0.9
         ```perl
         use Rex::Transaction;
         task "do_something", sub {
-          on_rollback {
-            unlink "/tmp/test";
-          };
+            on_rollback {
+                unlink "/tmp/test";
+            };
         
-          touch "/tmp/test";
-          die;
+            touch "/tmp/test";
+            die;
         };
         
         task "make", sub {
-          transaction {
-            do_task "do_something";
-          };
+            transaction {
+                do_task "do_something";
+            };
         };
         ```
 
@@ -40,8 +40,8 @@ title: Release notes for 0.9
         use Data::Dumper;
         use Rex::Commands::Inventory;
         task "inventory", "server1", "server2", sub {
-          my $inventory = inventor();
-          print Dumper($inventory);
+            my $inventory = inventor();
+            print Dumper($inventory);
         };
         ```
 
@@ -51,11 +51,11 @@ title: Release notes for 0.9
 
         ```perl
         task "upload", "server1", sub {
-          file "$path/vhost.conf",
-            content => template("../../templates/vhost.conf.tpl"),
+            file "$path/vhost.conf",
+              content => template("../../templates/vhost.conf.tpl"),
         
-            # on change of the file, do something
-            on_change => sub { say "file was modified"; };
+              # on change of the file, do something
+              on_change => sub { say "file was modified"; };
         };
         ```
 

--- a/content/docs/release_notes/1.0.0.md
+++ b/content/docs/release_notes/1.0.0.md
@@ -37,18 +37,18 @@ To use this it is required to have *augtool* installed on your servers. This is 
     use Rex::Commands::Augeas;
     
     task "prepare", sub {
-      augeas
-        insert    => "/files/etc/hosts",
-        label     => "01",
-        after     => "/7",
-        ipaddr    => "192.168.2.23",
-        canonical => "frontend01";
+        augeas
+          insert    => "/files/etc/hosts",
+          label     => "01",
+          after     => "/7",
+          ipaddr    => "192.168.2.23",
+          canonical => "frontend01";
     
-      augeas modify =>
-        "/files/etc/ssh/sshd_config/PermitRootLogin" => "without-password",
-        on_change                                    => sub {
-        service sshd => "restart";
-        };
+        augeas modify =>
+          "/files/etc/ssh/sshd_config/PermitRootLogin" => "without-password",
+          on_change                                    => sub {
+            service sshd => "restart";
+          };
     };
     ```
 
@@ -64,21 +64,21 @@ The PkgConf commands are especially usefull on debian/ubuntu systems to query an
     use Rex::Commands::PkgConf;
     
     task "prepare", sub {
-      set_pkgconf(
-        "mysql-server-5.5",
-        [
-          {
-            question => 'mysql-server/root_password',
-            type     => 'string',
-            value    => 'mysecret'
-          },
-          {
-            question => 'mysql-server/root_password_again',
-            type     => 'string',
-            value    => 'mysecret'
-          },
-        ]
-      );
+        set_pkgconf(
+            "mysql-server-5.5",
+            [
+                {
+                    question => 'mysql-server/root_password',
+                    type     => 'string',
+                    value    => 'mysecret'
+                },
+                {
+                    question => 'mysql-server/root_password_again',
+                    type     => 'string',
+                    value    => 'mysecret'
+                },
+            ]
+        );
     };
     ```
 

--- a/content/docs/release_notes/1.2.0.md
+++ b/content/docs/release_notes/1.2.0.md
@@ -18,9 +18,9 @@ Now it is possible to merge CMDB data from different levels of the CMDB hierarch
 
     ```perl
     set cmdb {
-      type           => 'YAML',
-      path           => 'cmdb',
-      merge_behavior => 'LEFT_PRECEDENT',
+        type           => 'YAML',
+        path           => 'cmdb',
+        merge_behavior => 'LEFT_PRECEDENT',
     };
     ```
 
@@ -30,13 +30,13 @@ Now it is possible to merge CMDB data from different levels of the CMDB hierarch
 
     ```perl
     set cmdb {
-      type           => 'YAML',
-      path           => 'cmdb',
-      merge_behavior => {
-        SCALAR => {...},
-        ARRAY  => {...},
-        HASH   => {...}
-      },
+        type           => 'YAML',
+        path           => 'cmdb',
+        merge_behavior => {
+            SCALAR => {...},
+            ARRAY  => {...},
+            HASH   => {...}
+        },
     };
     ```
 

--- a/content/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.md
+++ b/content/docs/rex_book/infrastructure/example_of_a_complete_rex_code_infrastructure.md
@@ -100,15 +100,12 @@ Load all server groups from the file **server.ini**.
 
     ```perl
     set cmdb => {
-      type => "YAML",
-      path => [
-        "cmdb/{operatingsystem}/{hostname}.yml",
-        "cmdb/{operatingsystem}/default.yml",
-        "cmdb/{environment}/{hostname}.yml",
-        "cmdb/{environment}/default.yml",
-        "cmdb/{hostname}.yml",
-        "cmdb/default.yml",
-      ],
+        type => "YAML",
+        path => [
+            "cmdb/{operatingsystem}/{hostname}.yml", "cmdb/{operatingsystem}/default.yml",
+            "cmdb/{environment}/{hostname}.yml",     "cmdb/{environment}/default.yml",
+            "cmdb/{hostname}.yml",                   "cmdb/default.yml",
+        ],
     };
     ```
 
@@ -166,11 +163,11 @@ It is also possible to define the server or group to connect to.
 
     ```perl
     make {
-      # run setup() task of Rex::OS::Base module
-      Rex::OS::Base::setup();
+        # run setup() task of Rex::OS::Base module
+        Rex::OS::Base::setup();
     
-      # run setup() task of Rex::NTP::Base module
-      Rex::NTP::Base::setup();
+        # run setup() task of Rex::NTP::Base module
+        Rex::NTP::Base::setup();
     };
     ```
 
@@ -202,10 +199,10 @@ Load the **Rex::Test::Base** framework and the Rex basic commands.
 
     ```perl
     test {
-      my $t = shift;
-      $t->name("ubuntu test");
+        my $t = shift;
+        $t->name("ubuntu test");
     
-      # we will add more code here in a bit
+        # we will add more code here in a bit
     };
     1;
     ```

--- a/content/docs/rex_book/infrastructure/ssh_as_an_agent.md
+++ b/content/docs/rex_book/infrastructure/ssh_as_an_agent.md
@@ -40,7 +40,7 @@ If you have many servers you want to connect to, you usually don't want to conne
     task "prepare",
       group => "frontends",
       sub {
-      # do something
+        # do something
       };
     ```
 

--- a/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
+++ b/content/docs/rex_book/managing_datacenters_and_the_cloud/deploying_openldap_and_sssd.md
@@ -86,7 +86,7 @@ In the Rexfile you'll find the task setup\_server.
     task "setup_server",
       group => "server",
       make {
-      # we will add more code here in a bit
+        # we will add more code here in a bit
       };
     ```
 
@@ -94,10 +94,10 @@ This task is configured to run on all servers registered in the group server.
 
     ```perl
     Rex::LDAP::OpenLDAP::setup {
-      ldap_admin_password         => 'admin',
-      ldap_base_dn                => 'dc=rexify,dc=org',
-      ldap_base_dn_admin_password => 'test',
-      ldap_configure_tls          => TRUE,
+        ldap_admin_password         => 'admin',
+        ldap_base_dn                => 'dc=rexify,dc=org',
+        ldap_base_dn_admin_password => 'test',
+        ldap_configure_tls          => TRUE,
     };
     
     Rex::LDAP::OpenLDAP::UserManagement::Server::add_ssh_public_key;
@@ -185,7 +185,7 @@ Now, after you have setup OpenLDAP it is time to setup SSSD. For this there is a
     task "setup_client",
       group => "client",
       make {
-      # we will add more code here in a bit
+        # we will add more code here in a bit
       };
     ```
 
@@ -193,13 +193,13 @@ This task is configured to run on all servers inside the group client.
 
     ```perl
     Rex::LDAP::OpenLDAP::UserManagement::Client::setup {
-      ldap_base_dn       => 'dc=rexify,dc=org',
-      ldap_uri           => 'ldaps://10.211.55.168',
-      ldap_bind_dn       => 'cn=sssd,ou=Services,dc=rexify,dc=org',
-      ldap_bind_password => 'abcdef',
-      ldap_base_user_dn  => 'ou=People,dc=rexify,dc=org',
-      ldap_base_group_dn => 'ou=Groups,dc=rexify,dc=org',
-      configure_ssh_ldap => TRUE,
+        ldap_base_dn       => 'dc=rexify,dc=org',
+        ldap_uri           => 'ldaps://10.211.55.168',
+        ldap_bind_dn       => 'cn=sssd,ou=Services,dc=rexify,dc=org',
+        ldap_bind_password => 'abcdef',
+        ldap_base_user_dn  => 'ou=People,dc=rexify,dc=org',
+        ldap_base_group_dn => 'ou=Groups,dc=rexify,dc=org',
+        configure_ssh_ldap => TRUE,
     };
     ```
 

--- a/content/docs/rex_book/the_rex_dsl/grouping_servers.md
+++ b/content/docs/rex_book/the_rex_dsl/grouping_servers.md
@@ -34,7 +34,7 @@ To add your groups to the tasks you have to use the group option within the task
     task "mytask",
       group => "mygroup",
       sub {
-      # do something
+        # do something
       };
     ```
 
@@ -44,7 +44,7 @@ If you need to define multiple groups for a task, you can just use an array.
     task "mytask",
       group => [ "mygroup", "mygroup2" ],
       sub {
-      # do something
+        # do something
       };
     ```
 
@@ -91,10 +91,10 @@ These additional options (in this example maintenance can be queried with the op
     task "prepare",
       group => "frontends",
       sub {
-      if ( connection->server->option("maintenance") ) {
-        say "This server is in maintenance mode, so i'm going to stop all services";
-        service [ "apache2", "postfix" ] => "stop";
-      }
+        if ( connection->server->option("maintenance") ) {
+            say "This server is in maintenance mode, so i'm going to stop all services";
+            service [ "apache2", "postfix" ] => "stop";
+        }
       };
     ```
 
@@ -118,9 +118,9 @@ If you want to get your server groups right out of an existing database you can 
     
     my %server_group = ();
     while ( my $row = $sth->fetchrow_hashref ) {
-      my $group_name  = $row->{server_group};
-      my $server_name = $row->{server_name};
-      push @{ $server_group{$group_name} }, $server_name;
+        my $group_name  = $row->{server_group};
+        my $server_name = $row->{server_name};
+        push @{ $server_group{$group_name} }, $server_name;
     }
     
     map { group $_ => @{ $server_group{$_} }; } keys %server_group;

--- a/content/docs/rex_book/the_rex_dsl/using_environments.md
+++ b/content/docs/rex_book/the_rex_dsl/using_environments.md
@@ -19,36 +19,36 @@ Creating environments is as easy as creating groups. To create environments you 
     use Rex -feature => ['1.0'];
     
     environment test => sub {
-      user "root";
-      password "b0x";
+        user "root";
+        password "b0x";
     
-      group frontend   => "fe01.test";
-      group middleware => "mw01.test";
-      group dbwrite    => "dbm01.test";
+        group frontend   => "fe01.test";
+        group middleware => "mw01.test";
+        group dbwrite    => "dbm01.test";
     };
     
     environment stage => sub {
-      user "root";
-      password "b0xst4g3";
+        user "root";
+        password "b0xst4g3";
     
-      group loadbalancer => "lb01.stage";
-      group frontend     => "fe01.stage";
-      group middleware   => "mw01.stage";
-      group dbread       => "dbs01.stage";
-      group dbwrite      => "dbm01.stage";
+        group loadbalancer => "lb01.stage";
+        group frontend     => "fe01.stage";
+        group middleware   => "mw01.stage";
+        group dbread       => "dbs01.stage";
+        group dbwrite      => "dbm01.stage";
     };
     
     environment live => sub {
-      user "admin";
-      password "b0xl1v3";
-      sudo_password "b0xl1v3";
-      sudo TRUE;
+        user "admin";
+        password "b0xl1v3";
+        sudo_password "b0xl1v3";
+        sudo TRUE;
     
-      group loadbalancer => "lb[01..02].live";
-      group frontend     => "fe[01..03].live";
-      group middleware   => "mw[01..02].live";
-      group dbread       => "dbs[01..02].live";
-      group dbwrite      => "dbm01.live";
+        group loadbalancer => "lb[01..02].live";
+        group frontend     => "fe[01..03].live";
+        group middleware   => "mw[01..02].live";
+        group dbread       => "dbs[01..02].live";
+        group dbwrite      => "dbm01.live";
     };
     ```
 
@@ -65,20 +65,20 @@ If you need to configure systems depending on the environment you can get the cu
     task "prepare",
       group => "frontend",
       make {
-      # configure ntp.conf depending on the environment
-      my $ntp_server = case environment, {
-        test      => ["ntp01.test"],
-          stage   => ["ntp01.stage"],
-          live    => [ "ntp01.live", "ntp02.live" ],
-          default => ["ntp01.test"],
-      };
+        # configure ntp.conf depending on the environment
+        my $ntp_server = case environment, {
+            test      => ["ntp01.test"],
+              stage   => ["ntp01.stage"],
+              live    => [ "ntp01.live", "ntp02.live" ],
+              default => ["ntp01.test"],
+        };
     
-      file "/etc/ntp.conf",
-        content => template( "templates/etc/ntp.conf", ntp_server => $ntp_server ),
-        owner   => "root",
-        group   => "root",
-        mode    => 644,
-        on_change => make { service ntpd => "restart"; };
+        file "/etc/ntp.conf",
+          content   => template( "templates/etc/ntp.conf", ntp_server => $ntp_server ),
+          owner     => "root",
+          group     => "root",
+          mode      => 644,
+          on_change => make { service ntpd => "restart"; };
       };
     ```
 
@@ -122,22 +122,22 @@ To use the CMDB you have to require and configure the Rex::CMDB module first.
     use Rex::CMDB;
     
     set cmdb => {
-      type => "YAML",
-      path => "./cmdb",
+        type => "YAML",
+        path => "./cmdb",
     };
     
     task "prepare",
       group => "frontend",
       make {
-      # configure ntp.conf depending on the environment
-      my $ntp_server = get cmdb "ntp_server";
+        # configure ntp.conf depending on the environment
+        my $ntp_server = get cmdb "ntp_server";
     
-      file "/etc/ntp.conf",
-        content => template( "templates/etc/ntp.conf", ntp_server => $ntp_server ),
-        owner   => "root",
-        group   => "root",
-        mode    => 644,
-        on_change => make { service ntpd => "restart"; };
+        file "/etc/ntp.conf",
+          content   => template( "templates/etc/ntp.conf", ntp_server => $ntp_server ),
+          owner     => "root",
+          group     => "root",
+          mode      => 644,
+          on_change => make { service ntpd => "restart"; };
       };
     ```
 

--- a/content/docs/rex_book/the_rex_dsl/using_templates.md
+++ b/content/docs/rex_book/the_rex_dsl/using_templates.md
@@ -54,17 +54,17 @@ Than you can reference on it from within your Rexfile.
     task "prepare_databases",
       group => "databases",
       sub {
-      file "/etc/my.cnf",
-        owner   => "root",
-        group   => "root",
-        mode    => "644",
-        content => template(
-        "files/my.cnf.tpl",
-        conf => {
-          max_connections => "500",
-          table_cache     => "2500",
-        }
-        );
+        file "/etc/my.cnf",
+          owner   => "root",
+          group   => "root",
+          mode    => "644",
+          content => template(
+            "files/my.cnf.tpl",
+            conf => {
+                max_connections => "500",
+                table_cache     => "2500",
+            }
+          );
       };
     ```
 
@@ -78,15 +78,15 @@ When you want to deliver a rexfile that includes the templates, you can use inli
     use Rex -feature => ['1.0'];
     
     task tempfiles => sub {
-      file '/tmp/test.txt' => content => template(
-        '@test',
-        test => {
-          author => 'reneeb',
-          target => 'rex',
-        },
-        ),
-        chmod => 644,
-        ;
+        file '/tmp/test.txt' => content => template(
+            '@test',
+            test => {
+                author => 'reneeb',
+                target => 'rex',
+            },
+          ),
+          chmod => 644,
+          ;
     };
     
     __DATA__
@@ -105,25 +105,25 @@ Rex knows that it has to look up the template in the `__DATA__` section of the f
     ```perl
     use Rex -feature => ['1.0'];
     task tempfiles   => sub {
-      file '/tmp/test.txt' => content => template(
-        '@test',
-        test => {
-          author => 'reneeb',
-          target => 'rex',
-        },
-        ),
-        chmod => 644,
-        ;
+        file '/tmp/test.txt' => content => template(
+            '@test',
+            test => {
+                author => 'reneeb',
+                target => 'rex',
+            },
+          ),
+          chmod => 644,
+          ;
     
-      file '/tmp/rex.txt' => content => template(
-        '@rex',
-        test => {
-          author => 'krimdomu',
-          target => 'rex',
-        },
-        ),
-        chmod => 644,
-        ;
+        file '/tmp/rex.txt' => content => template(
+            '@rex',
+            test => {
+                author => 'krimdomu',
+                target => 'rex',
+            },
+          ),
+          chmod => 644,
+          ;
     };
     
     __DATA__

--- a/content/docs/rex_book/working_with_files_and_packages/installing_packages.md
+++ b/content/docs/rex_book/working_with_files_and_packages/installing_packages.md
@@ -13,7 +13,7 @@ Installing packages is easy. You can use the pkg function for this.
     task "prepare_system",
       group => "frontends",
       sub {
-      pkg "apache2", ensure => "present";
+        pkg "apache2", ensure => "present";
       };
     ```
 
@@ -28,7 +28,7 @@ If you have to install multiple packages you can use an array so that you don't 
     task "prepare_system",
       group => "frontends",
       sub {
-      pkg [ "apache2", "libphp5-apache2", "mysql-server" ], ensure => "present";
+        pkg [ "apache2", "libphp5-apache2", "mysql-server" ], ensure => "present";
       };
     ```
 
@@ -43,10 +43,10 @@ If you need to write a distribution independent module you can also use the case
     task "prepare_system",
       group => "frontends",
       sub {
-      my $packages = case operating_system,
-        Debian => [ "apache2", "libphp5-apache2" ],
-        CentOS => [ "httpd",   "php5" ],
+        my $packages = case operating_system,
+          Debian => [ "apache2", "libphp5-apache2" ],
+          CentOS => [ "httpd",   "php5" ],
     
-        pkg $packages, ensure => "present";
+          pkg $packages, ensure => "present";
       };
     ```

--- a/content/docs/rex_book/working_with_files_and_packages/working_with_files.md
+++ b/content/docs/rex_book/working_with_files_and_packages/working_with_files.md
@@ -11,7 +11,7 @@ If you need to verify that a given line exists or gets removed from a file you c
     ```perl
     # Rexfile
     task "setup", sub {
-      append_if_no_such_line "/etc/modules", "loop";
+        append_if_no_such_line "/etc/modules", "loop";
     };
     ```
 
@@ -24,9 +24,9 @@ It is also possible to define more complex rules. For example if you want to use
     ```perl
     # Rexfile
     task "setup", sub {
-      append_if_no_such_line "/etc/modprobe.d/thinkfan.conf",
-        line   => "options thinkpad_acpi fan_control=1",
-        regexp => qr{thinkpad_acpi};
+        append_if_no_such_line "/etc/modprobe.d/thinkfan.conf",
+          line   => "options thinkpad_acpi fan_control=1",
+          regexp => qr{thinkpad_acpi};
     };
     ```
 
@@ -39,10 +39,10 @@ You can also execute code if the file was changed, for example to restart servic
     ```perl
     # Rexfile
     task "setup", sub {
-      append_if_no_such_line "/etc/nagios/hosts.d/frontends.cfg",
-        line      => template( "templates/nagios/host.cfg.tpl", %tpl_variables ),
-        regexp    => qr/\s*host_name\s*$host/,
-        on_change => sub { service nagios => "reload"; };
+        append_if_no_such_line "/etc/nagios/hosts.d/frontends.cfg",
+          line      => template( "templates/nagios/host.cfg.tpl", %tpl_variables ),
+          regexp    => qr/\s*host_name\s*$host/,
+          on_change => sub { service nagios => "reload"; };
     };
     ```
 
@@ -53,8 +53,8 @@ If you need to remove a line you can use delete\_lines\_according\_to.
     ```perl
     # Rexfile
     task "setup", sub {
-      delete_lines_according_to qr{loop}, "/etc/modules",
-        on_change => sub { say "file was modified."; };
+        delete_lines_according_to qr{loop}, "/etc/modules",
+          on_change => sub { say "file was modified."; };
     };
     ```
 
@@ -72,24 +72,24 @@ For this you can use the Rex::Commands::Concat module from http://modules.rexify
     use Rex::Commands::Concat;
     
     task "prepare", sub {
-      concat_fragment "config-header",
-        target  => "/etc/some.conf",
-        content => "# managed by Rex\n",
-        order   => "01";
+        concat_fragment "config-header",
+          target  => "/etc/some.conf",
+          content => "# managed by Rex\n",
+          order   => "01";
     
-      concat_fragment "listen-entry",
-        target  => "/etc/some.conf",
-        content => "Listen *:80\n",
-        order   => "20";
+        concat_fragment "listen-entry",
+          target  => "/etc/some.conf",
+          content => "Listen *:80\n",
+          order   => "20";
     };
     
     task "setup", sub {
-      concat "/etc/some.conf",
-        ensure    => "present",
-        owner     => "root",
-        group     => "root",
-        mode      => 644,
-        on_change => sub { say "changed..."; };
+        concat "/etc/some.conf",
+          ensure    => "present",
+          owner     => "root",
+          group     => "root",
+          mode      => 644,
+          on_change => sub { say "changed..."; };
     };
     ```
 
@@ -104,7 +104,7 @@ If you want to manage complete files you can use the file() resource to do so. T
     use Rex -feature => ['1.0'];
     
     task "setup", sub {
-      file "/etc/my.conf", source => "files/etc/my.conf";
+        file "/etc/my.conf", source => "files/etc/my.conf";
     };
     ```
 
@@ -117,11 +117,11 @@ You can also define the permissions for the file.
     use Rex -feature => ['1.0'];
     
     task "setup", sub {
-      file "/etc/my.conf",
-        source => "files/etc/my.conf",
-        owner  => "root",
-        group  => "root",
-        mode   => 600;
+        file "/etc/my.conf",
+          source => "files/etc/my.conf",
+          owner  => "root",
+          group  => "root",
+          mode   => 600;
     };
     ```
 
@@ -132,12 +132,12 @@ If you want to execute a command when the file was changed, you can use the on\_
     use Rex -feature => ['1.0'];
     
     task "setup", sub {
-      file "/etc/my.conf",
-        source    => "files/etc/my.conf",
-        owner     => "root",
-        group     => "root",
-        mode      => 600,
-        on_change => sub { service mysqld => "restart"; };
+        file "/etc/my.conf",
+          source    => "files/etc/my.conf",
+          owner     => "root",
+          group     => "root",
+          mode      => 600,
+          on_change => sub { service mysqld => "restart"; };
     };
     ```
 
@@ -152,10 +152,10 @@ It is also possible to just supervise files if they are present or have special 
     use Rex -feature => ['1.0'];
     
     task "setup", sub {
-      file "/etc/my.conf",
-        ensure => "present",
-        owner  => "root",
-        group  => "root",
-        mode   => 600;
+        file "/etc/my.conf",
+          ensure => "present",
+          owner  => "root",
+          group  => "root",
+          mode   => 600;
     };
     ```

--- a/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
+++ b/content/docs/rex_book/writing_modules/getting_information_of_the_environment.md
@@ -10,7 +10,7 @@ Rex comes with a hardware gathering module. To display all the things Rex knows 
     use Rex -feature => ['1.0'];
     
     task "dump-info", sub {
-      dump_system_information;
+        dump_system_information;
     };
     ```
 
@@ -92,16 +92,16 @@ To use these information inside the Rexfile you can query them with the get\_sys
     use Rex -feature => ['1.0'];
     
     task "get_hostname", sub {
-      my %info = get_system_information;
-      say $info{hostname} . "." . $info{domain};
+        my %info = get_system_information;
+        say $info{hostname} . "." . $info{domain};
     };
     
     use Rex -feature => ['1.0'];
     
     task "prepare", sub {
-      my $libpath = case connection->server->architecture,
-        "i386"   => "/usr/lib",
-        "x86_64" => "/usr/lib64";
+        my $libpath = case connection->server->architecture,
+          "i386"   => "/usr/lib",
+          "x86_64" => "/usr/lib64";
     };
     ```
 

--- a/content/docs/rex_book/writing_modules/writing_custom_resources.md
+++ b/content/docs/rex_book/writing_modules/writing_custom_resources.md
@@ -77,44 +77,44 @@ The *\_\_module\_\_.pm* file which creates the resource.
     
     # list the available providers
     my $__provider = {
-      default => "HelloWorld::greet::Provider::default",
-      CentOS  => "HelloWorld::greet::Provider::centos",
+        default => "HelloWorld::greet::Provider::default",
+        CentOS  => "HelloWorld::greet::Provider::centos",
     };
     
     # create a resource HelloWorld::greet
     resource "greet", sub {
-      my $rule_name = resource_name;
+        my $rule_name = resource_name;
     
-      my $rule_config = {
-        ensure  => param_lookup( "ensure",  "present" ),
-        message => param_lookup( "message", "<default value>" ),
-      };
+        my $rule_config = {
+            ensure  => param_lookup( "ensure",  "present" ),
+            message => param_lookup( "message", "<default value>" ),
+        };
     
-      # get the right provider if it is not defined via the operating system
-      # and the list from above.
-      my $provider =
-        param_lookup( "provider", case ( lc(operating_system), $__provider ) );
+        # get the right provider if it is not defined via the operating system
+        # and the list from above.
+        my $provider =
+          param_lookup( "provider", case ( lc(operating_system), $__provider ) );
     
-      # load the provider class
-      $provider->require;
+        # load the provider class
+        $provider->require;
     
-      # create a new instance of the provider class
-      my $provider_o = $provider->new();
+        # create a new instance of the provider class
+        my $provider_o = $provider->new();
     
-      # and execute the requested state.
-      if ( $rule_config->{ensure} eq "present" ) {
-        if ( $provider_o->present($rule_config) ) {
-          emit created, "HelloWorld::greet resource created.";
+        # and execute the requested state.
+        if ( $rule_config->{ensure} eq "present" ) {
+            if ( $provider_o->present($rule_config) ) {
+                emit created, "HelloWorld::greet resource created.";
+            }
         }
-      }
-      elsif ( $rule_config->{ensure} eq "absent" ) {
-        if ( $provider_o->absent($rule_config) ) {
-          emit removed, "HelloWorld::greet resource removed.";
+        elsif ( $rule_config->{ensure} eq "absent" ) {
+            if ( $provider_o->absent($rule_config) ) {
+                emit removed, "HelloWorld::greet resource removed.";
+            }
         }
-      }
-      else {
-        die "Error: $rule_config->{ensure} not a valid option for 'ensure'.";
-      }
+        else {
+            die "Error: $rule_config->{ensure} not a valid option for 'ensure'.";
+        }
     
     };
     
@@ -148,41 +148,41 @@ bare class by our self.
     
     # the constructor
     sub new {
-      my $that  = shift;
-      my $proto = ref($that) || $that;
-      my $self  = {@_};
+        my $that  = shift;
+        my $proto = ref($that) || $that;
+        my $self  = {@_};
     
-      bless( $self, $proto );
+        bless( $self, $proto );
     
-      return $self;
+        return $self;
     }
     
     # the ensure methods
     sub present {
-      my ( $self, $rule_config ) = @_;
+        my ( $self, $rule_config ) = @_;
     
-      my $changed = 0;
+        my $changed = 0;
     
-      file "/etc/motd",
-        content   => $rule_config->{message},
-        owner     => "root",
-        group     => "root",
-        mode      => '0644',
-        on_change => sub { $changed = 1; };
+        file "/etc/motd",
+          content   => $rule_config->{message},
+          owner     => "root",
+          group     => "root",
+          mode      => '0644',
+          on_change => sub { $changed = 1; };
     
-      return $changed;
+        return $changed;
     }
     
     sub absent {
-      my ( $self, $rule_config ) = @_;
+        my ( $self, $rule_config ) = @_;
     
-      my $changed = 0;
+        my $changed = 0;
     
-      file "/etc/motd",
-        ensure    => "absent",
-        on_change => sub { $changed = 1; };
+        file "/etc/motd",
+          ensure    => "absent",
+          on_change => sub { $changed = 1; };
     
-      return $changed;
+        return $changed;
     }
     
     1; # this need to be the last line in the file
@@ -204,15 +204,15 @@ purpose how to do inheritance.
     
     # the constructor
     sub new {
-      my $that  = shift;
-      my $proto = ref($that) || $that;
+        my $that  = shift;
+        my $proto = ref($that) || $that;
     
-      # here we call the constructor of the parent class
-      my $self = $proto->SUPER::new(@_);
+        # here we call the constructor of the parent class
+        my $self = $proto->SUPER::new(@_);
     
-      bless( $self, $proto );
+        bless( $self, $proto );
     
-      return $self;
+        return $self;
     }
     
     1; # this need to be the last line in the file
@@ -234,12 +234,12 @@ resource in your `Rexfile`.
     task "prepare",
       group => "myservers",
       sub {
-      HelloWorld::greet "mygreeting",
-        message   => "Welcome to my server",
-        ensure    => "present",
-        on_change => sub {
-        say "server greeting has changed.";
-        };
+        HelloWorld::greet "mygreeting",
+          message   => "Welcome to my server",
+          ensure    => "present",
+          on_change => sub {
+            say "server greeting has changed.";
+          };
       };
     ```
 

--- a/content/index.md
+++ b/content/index.md
@@ -52,7 +52,7 @@ The same, but with a Rexfile
     
     desc 'Get uptime';
     task 'uptime', 'frontend[01..05]', sub {
-      say run 'uptime';
+        say run 'uptime';
     };
     ```
 
@@ -74,20 +74,20 @@ This example will install the Apache web server on 5 machines and keep their con
     task 'prepare',
       group => 'frontend',
       sub {
-      pkg 'apache2', ensure => 'present';
+        pkg 'apache2', ensure => 'present';
     
-      service 'apache2', ensure => 'started';
+        service 'apache2', ensure => 'started';
       };
     
     desc 'Keep configuration in sync';
     task 'configure',
       group => 'frontend',
       sub {
-      prepare();
+        prepare();
     
-      file '/etc/apache2/apache2.conf',
-        source    => 'files/etc/apache2/apache2.conf',
-        on_change => sub { service apache2 => 'reload'; };
+        file '/etc/apache2/apache2.conf',
+          source    => 'files/etc/apache2/apache2.conf',
+          on_change => sub { service apache2 => 'reload'; };
       };
     ```
 

--- a/misc/tidy_codeblocks
+++ b/misc/tidy_codeblocks
@@ -12,9 +12,9 @@ my @files = @ARGV;
 @ARGV = ();
 
 for my $file (@files) {
-  my $text = path($file)->slurp;
+    my $text = path($file)->slurp;
 
-  $text =~ s/
+    $text =~ s/
         (?<=```perl\n)
         (?<code>.+?)
         (?=\n\s+```)
@@ -22,34 +22,34 @@ for my $file (@files) {
         tidy($+{code});
     /egmsx;
 
-  path($file)->spew($text);
+    path($file)->spew($text);
 }
 
 sub tidy {
-  my $code = shift;
-  my $result;
-  my $stderr;
+    my $code = shift;
+    my $result;
+    my $stderr;
 
-  my ($indent) = $code =~ m{^(\s+)};
+    my ($indent) = $code =~ m{^(\s+)};
 
-  $code =~ s/^$indent//gm; # remove indent
+    $code =~ s/^$indent//gm; # remove indent
 
-  my $error = Perl::Tidy::perltidy(
-    source      => \$code,
-    destination => \$result,
-    errorfile   => \$stderr,
-  );
+    my $error = Perl::Tidy::perltidy(
+        source      => \$code,
+        destination => \$result,
+        errorfile   => \$stderr,
+    );
 
-  if ( defined $stderr ) {
-    say 'CODE';
-    say $code;
+    if ( defined $stderr ) {
+        say 'CODE';
+        say $code;
 
-    say 'ERROR';
-    say $stderr;
-  }
+        say 'ERROR';
+        say $stderr;
+    }
 
-  $result =~ s/^/$indent/gm; # add back indent
-  chomp $result;             # remove trailing newline
+    $result =~ s/^/$indent/gm; # add back indent
+    chomp $result;             # remove trailing newline
 
-  return $result;
+    return $result;
 }


### PR DESCRIPTION
Use the default 4 columns of indentation instead of 2, and compensate
for the extra leading space by allowing variable maximum line lengths.

I find this to be producing more readable output in many cases, especially for line continuations inside anonymous sub blocks (task definitions, `on_change`, etc.), while being a bit closer to default perltidy settings.