### PR TITLE
Release-1.8.0

### DIFF
--- a/blog/2020/01/05/rex-1.8.0.md
+++ b/blog/2020/01/05/rex-1.8.0.md
@@ -1,0 +1,8 @@
+---
+title: Rex-1.8.0
+author: Ferenc Erki
+date: 2020-01-05
+tags: news
+---
+
+The [Rex-1.8.0 release](/docs/release_notes/1.8.0.html) is now available on [CPAN](https://metacpan.org/release/Rex), adding initial support to manage Void Linux systems.

--- a/content/docs/release_notes/1.8.0.md
+++ b/content/docs/release_notes/1.8.0.md
@@ -1,0 +1,42 @@
+---
+title: Release notes for 1.8.0
+---
+
+This is a new minor release, most notably adding initial support to manage Void
+Linux systems. Upgrade is recommended for all users.
+
+We would like to welcome Leah Neukirchen as new contributor, and many thanks to
+all contributors who made this release possible!
+
+## Release highlights
+
+### Initial support to manage Void Linux systems
+
+  * Added Rex::Pkg::VoidLinux using XBPS - Leah Neukirchen
+  * Added Rex::Service::VoidLinux using runit - Leah Neukirchen
+  * Added Void Linux - Leah Neukirchen
+
+It is now possible to manage packages and services on Void Linux systems.
+
+## New features
+
+  * Make waitpid blocking sleep time configurable - Ferenc Erki
+
+If really needed, it could be tuned using e.g.
+`set waitpid_blocking_sleep_time => 0.001;` (time in seconds). Setting it to a
+low value might help speed up cases when Rex is managing the local machine, and
+higher values might help on high latency networks. Default is 0.1s.
+
+  * Map commit authors to their canonical name and email - Ferenc Erki
+  * Add contributors without commits on master branch - Ferenc Erki
+  * Generate CONTRIBUTORS file - Ferenc Erki
+  * Add Kwalitee tests - Ferenc Erki
+
+## Enhancements
+
+  * Match waitpid blocking sleep between fork managers - Ferenc Erki
+
+## Bugfixes
+
+  * Update Perl::Tidy on each Travis build - Ferenc Erki
+  * Skip bin tidiness check on Windows and Mac - Ferenc Erki


### PR DESCRIPTION
This PR adds release notes and news entry for rex-1.8.0. Given successful tests, it will be merged right after the release is uploaded to CPAN.